### PR TITLE
Allow writing dataframes as Parquet and IPC files

### DIFF
--- a/core/src/main/scala/org/polars/scala/polars/api/DataFrame.scala
+++ b/core/src/main/scala/org/polars/scala/polars/api/DataFrame.scala
@@ -1,6 +1,7 @@
 package org.polars.scala.polars.api
 
 import org.polars.scala.polars.api.expressions.Expression
+import org.polars.scala.polars.api.io.Writeable
 import org.polars.scala.polars.api.types.Schema
 import org.polars.scala.polars.internal.jni.data_frame
 
@@ -32,6 +33,7 @@ class DataFrame private (private[polars] val ptr: Long) {
   def show(): Unit = data_frame.show(ptr)
 
   def count(): Long = data_frame.count(ptr)
+  def write(): Writeable = new Writeable(ptr)
 
 }
 

--- a/core/src/main/scala/org/polars/scala/polars/api/io/Writeable.scala
+++ b/core/src/main/scala/org/polars/scala/polars/api/io/Writeable.scala
@@ -1,3 +1,122 @@
 package org.polars.scala.polars.api.io
 
-class Writeable {}
+import java.util.Locale
+
+import scala.collection.mutable.{Map => MutableMap}
+import scala.jdk.CollectionConverters._
+
+import org.json4s.native.Serialization
+import org.polars.scala.polars.internal.jni.io.write._
+
+object WriteCompressions extends Enumeration {
+  type WriteCompression = Value
+
+  private lazy val stringMap: Map[String, WriteCompression] =
+    values.map(v => (v.toString.toLowerCase(Locale.ROOT), v)).toMap
+
+  def fromString(str: String): Option[WriteCompression] = stringMap.get(str)
+
+  val lz4, uncompressed, snappy, gzip, lzo, brotli, zstd = Value
+}
+
+object WriteModes extends Enumeration {
+  type WriteMode = Value
+
+  private lazy val stringMap: Map[String, WriteMode] =
+    values.map(v => (v.toString.toLowerCase(Locale.ROOT), v)).toMap
+
+  def fromString(str: String): Option[WriteMode] = stringMap.get(str)
+
+  val ErrorIfExists, Overwrite = Value
+}
+
+class Writeable private[polars] (ptr: Long) {
+  import org.polars.scala.polars.formats
+
+  private var _mode: String = WriteModes.ErrorIfExists.toString
+  private var _compression: String = WriteCompressions.snappy.toString
+  private var _compressionLevel: Int = -1
+  private val _options: MutableMap[String, String] = MutableMap.empty
+
+  def compression(
+      value: WriteCompressions.WriteCompression,
+      level: Option[Int]
+  ): Writeable = synchronized {
+    _compression = value.toString
+    level match {
+      case Some(value) => _compressionLevel = value
+      case None =>
+    }
+
+    this
+  }
+
+  def compression(
+      value: String,
+      level: Option[Int] = None
+  ): Writeable = synchronized {
+    compression(
+      WriteCompressions
+        .fromString(value)
+        .getOrElse(
+          throw new IllegalArgumentException(
+            s"Provided value '$value' is not a valid write mode."
+          )
+        ),
+      level
+    )
+  }
+
+  def mode(value: WriteModes.WriteMode): Writeable = synchronized {
+    _mode = value.toString
+    this
+  }
+
+  def mode(value: String): Writeable = synchronized {
+    mode(
+      WriteModes
+        .fromString(value)
+        .getOrElse(
+          throw new IllegalArgumentException(
+            s"Provided value '$value' is not a valid write mode."
+          )
+        )
+    )
+  }
+
+  def withOption(key: String, value: String): Writeable = synchronized {
+    (key, value) match {
+      case (_, null) | (null, _) | (null, null) =>
+        throw new IllegalArgumentException("Option key or value cannot be null or empty.")
+
+      case (k, v) =>
+        _options.put(k.trim, v.trim)
+        this
+    }
+  }
+
+  def options(opts: java.util.Map[String, String]): Writeable = synchronized {
+    opts.asScala.foreach { case (key, value) => withOption(key, value) }
+
+    this
+  }
+
+  def options(opts: Iterable[(String, String)]): Writeable = synchronized {
+    opts.foreach { case (key, value) => withOption(key, value) }
+
+    this
+  }
+
+  def parquet(
+      filePath: String,
+      writeStats: Boolean = false): Unit =
+    writeParquet(
+      ptr = ptr,
+      filePath = filePath,
+      writeStats = writeStats,
+      compression = _compression,
+      compressionLevel = _compressionLevel,
+      options = Serialization.write(_options),
+      writeMode = _mode
+    )
+}

--- a/core/src/main/scala/org/polars/scala/polars/internal/jni/io/write.scala
+++ b/core/src/main/scala/org/polars/scala/polars/internal/jni/io/write.scala
@@ -1,0 +1,17 @@
+package org.polars.scala.polars.internal.jni.io
+
+import org.polars.scala.polars.internal.jni.Natively
+
+private[polars] object write extends Natively {
+
+  @native def writeParquet(
+      ptr: Long,
+      filePath: String,
+      writeStats: Boolean,
+      compression: String,
+      compressionLevel: Int,
+      options: String,
+      writeMode: String
+  ): Unit
+
+}

--- a/core/src/main/scala/org/polars/scala/polars/internal/jni/io/write.scala
+++ b/core/src/main/scala/org/polars/scala/polars/internal/jni/io/write.scala
@@ -14,4 +14,12 @@ private[polars] object write extends Natively {
       writeMode: String
   ): Unit
 
+  @native def writeIPC(
+      ptr: Long,
+      filePath: String,
+      compression: String,
+      options: String,
+      writeMode: String
+  ): Unit
+
 }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
  "ahash",
  "arrow-format",
  "avro-schema",
- "base64",
+ "base64 0.13.1",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -180,6 +180,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
@@ -291,6 +297,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "wasm-bindgen",
  "winapi",
@@ -556,6 +563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +579,15 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum_dispatch"
@@ -632,10 +654,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1b05cbd864bcaecbd3455d6d967862d446e4ebfc3c2e5e5b9841e53cba6673"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -755,6 +792,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "h2"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "halfbrown"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +865,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +957,16 @@ checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
 dependencies = [
  "cxx",
  "cxx-build",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -863,6 +1000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +1015,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1127,6 +1279,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1442,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ea8f683b4f89a64181393742c041520a1a87e9775e6b4c0dd5a3281af05fc6"
+dependencies = [
+ "async-trait",
+ "base64 0.21.0",
+ "bytes",
+ "chrono",
+ "futures",
+ "itertools",
+ "parking_lot 0.12.1",
+ "percent-encoding",
+ "quick-xml",
+ "rand",
+ "reqwest",
+ "ring",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1633,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "indexmap",
  "num",
+ "object_store",
  "once_cell",
  "polars-arrow",
  "polars-utils",
@@ -1451,6 +1644,7 @@ dependencies = [
  "serde",
  "smartstring",
  "thiserror",
+ "url",
  "wasm-timer",
  "xxhash-rust",
 ]
@@ -1464,14 +1658,17 @@ dependencies = [
  "ahash",
  "anyhow",
  "arrow2",
+ "async-trait",
  "bytes",
  "chrono",
  "dirs",
+ "futures",
  "lexical",
  "lexical-core",
  "memchr",
  "memmap2",
  "num",
+ "object_store",
  "once_cell",
  "polars-arrow",
  "polars-core",
@@ -1483,6 +1680,8 @@ dependencies = [
  "serde_json",
  "simd-json",
  "simdutf8",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1608,6 +1807,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1925,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "reqwest"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +2010,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,14 +2056,21 @@ name = "scala-polars-native"
 version = "0.1.0"
 dependencies = [
  "cargo-sort",
+ "futures",
  "jni",
  "jni_fn",
  "num",
  "num-derive",
  "num-traits",
+ "object_store",
  "polars",
  "polars-core",
+ "serde",
  "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -1791,6 +2084,16 @@ name = "scratch"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -1830,6 +2133,18 @@ version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1912,10 +2227,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "snafu"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -2054,10 +2407,139 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -2072,6 +2554,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2107,6 +2606,16 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
 ]
 
 [[package]]
@@ -2188,6 +2697,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2732,25 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -2308,6 +2849,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -2055,6 +2055,7 @@ dependencies = [
 name = "scala-polars-native"
 version = "0.1.0"
 dependencies = [
+ "arrow2",
  "cargo-sort",
  "futures",
  "jni",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -18,6 +18,7 @@ jni_fn = { git = "https://gitlab.com/antonok/jni_fn.git", branch = "scala-class-
 num = "0.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
+arrow2 = { version = "0.16.0", features=["io_ipc_write_async"]}
 polars-core = { version = "0.27.2", default-features = false }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -19,7 +19,14 @@ num = "0.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 polars-core = { version = "0.27.2", default-features = false }
-serde_json = "1.0.91"
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+url = "2.3"
+thiserror = "1"
+object_store = { version = "0.5", features=["aws", "azure", "gcp"]}
+tokio = { version = "1.18", features = ["sync", "macros", "rt", "time", "io-util", "net", "rt-multi-thread"] }
+tokio-util = { version = "0.7.7", features= ["compat"] }
+futures = "0.3.25"
 
 [dependencies.polars]
 version = "0.27.2"
@@ -39,6 +46,10 @@ features = [
     "strings",
     "serde",
     "serde-lazy",
+    "async",
+    "aws",
+    "gcp",
+    "azure"
 ]
 
 [profile.release]

--- a/native/src/internal_jni/io/mod.rs
+++ b/native/src/internal_jni/io/mod.rs
@@ -1,1 +1,2 @@
 pub mod scan;
+pub mod write;

--- a/native/src/internal_jni/io/write.rs
+++ b/native/src/internal_jni/io/write.rs
@@ -1,0 +1,139 @@
+#![allow(non_snake_case)]
+
+use std::collections::HashMap;
+
+use futures::SinkExt;
+use jni::JNIEnv;
+use jni::objects::{JObject, JString};
+use jni::sys::{jboolean, jint, jlong, JNI_TRUE};
+use jni_fn::jni_fn;
+use object_store::DynObjectStore;
+use object_store::path::Path;
+use polars::export::arrow::io::parquet::write as write_parquet;
+use polars::prelude::*;
+use tokio;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+use url::Url;
+
+use crate::internal_jni::utils::*;
+use crate::j_data_frame::JDataFrame;
+use crate::storage_config::StorageOptions;
+use crate::utils::{PathError, WriteModes};
+use crate::utils::write_utils::{
+    build_storage, get_encodings, parse_parquet_compression, parse_write_mode,
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn write_files(
+    object_store: &DynObjectStore,
+    prefix: Path,
+    url: Url,
+    write_opts: write_parquet::WriteOptions,
+    mut data_frame: DataFrame,
+    write_mode: WriteModes,
+) {
+    let meta = object_store.head(&prefix).await;
+
+    let ensure_write_mode =
+        if meta.is_ok() && write_mode == WriteModes::ErrorIfExists {
+            Err(PathError::FileAlreadyExists(String::from(url.as_str())))
+        } else {
+            Ok(())
+        };
+
+    ensure_write_mode.expect("Error encountered");
+
+    data_frame.rechunk();
+
+    let schema = data_frame.schema().to_arrow();
+    let encodings = get_encodings(&schema);
+    let mut iter = data_frame.iter_chunks();
+
+    let (_id, writer) = object_store
+        .clone()
+        .put_multipart(&prefix.clone())
+        .await
+        .expect("Error encountered while opening destination");
+
+    let mut sink =
+        write_parquet::FileSink::try_new(writer.compat_write(), schema, encodings, write_opts)
+            .expect("Error encountered while creating file sink");
+
+    while let Some(chunk) = iter.next() {
+        sink.feed(chunk)
+            .await
+            .expect("Error encountered while feeding chunk")
+    }
+
+    sink.close()
+        .await
+        .expect("Error encountered while closing file sink");
+}
+
+#[jni_fn("org.polars.scala.polars.internal.jni.io.write$")]
+pub fn writeParquet(
+    env: JNIEnv,
+    _object: JObject,
+    df_ptr: jlong,
+    filePath: JString,
+    writeStats: jboolean,
+    compression: JString,
+    compressionLevel: jint,
+    options: JString,
+    writeMode: JString,
+) {
+    let this_path = get_file_path(env, filePath);
+
+    let compression_str = get_string(
+        env,
+        compression,
+        "Unable to get/ convert compression string to UTF8.",
+    );
+
+    let write_mode_str = get_string(
+        env,
+        writeMode,
+        "Unable to get/ convert write mode string to UTF8.",
+    );
+    let compression_level = if compressionLevel.is_negative() {
+        None
+    } else {
+        Some(compressionLevel as i32)
+    };
+
+    let compression = parse_parquet_compression(&compression_str, compression_level)
+        .expect("Unable to parse the provided compression argument(s)");
+
+    let write_mode = parse_write_mode(&write_mode_str)
+        .expect("Unable to parse the provided write mode argument");
+
+    let options: StorageOptions = if options.is_null() {
+        StorageOptions(HashMap::new())
+    } else {
+        let json = get_string(env, options, "Unable to get/ convert storage options");
+        let options_map: HashMap<String, String> = serde_json::from_str(&json).unwrap();
+        StorageOptions(options_map)
+    };
+
+    let write_options = write_parquet::WriteOptions {
+        write_statistics: writeStats == JNI_TRUE,
+        version: write_parquet::Version::V2,
+        compression,
+        data_pagesize_limit: None,
+    };
+
+    let j_df = unsafe { &mut *(df_ptr as *mut JDataFrame) };
+    let data_frame = j_df.to_owned().df;
+
+    let object_store = build_storage(this_path.clone(), options)
+        .expect("Unable to instantiate object store from provided path");
+
+    write_files(
+        object_store.storage.as_ref(),
+        object_store.path,
+        object_store.url,
+        write_options,
+        data_frame,
+        write_mode,
+    );
+}

--- a/native/src/internal_jni/io/write/mod.rs
+++ b/native/src/internal_jni/io/write/mod.rs
@@ -1,0 +1,2 @@
+pub mod ipc;
+pub mod parquet;

--- a/native/src/internal_jni/io/write/parquet.rs
+++ b/native/src/internal_jni/io/write/parquet.rs
@@ -1,0 +1,172 @@
+#![allow(non_snake_case)]
+
+use arrow2::io::parquet::write as write_parquet;
+use futures::SinkExt;
+use jni::objects::{JObject, JString};
+use jni::sys::{jboolean, jint, jlong, JNI_TRUE};
+use jni::JNIEnv;
+use jni_fn::jni_fn;
+use object_store::path::Path;
+use object_store::DynObjectStore;
+use polars::prelude::*;
+use tokio;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+use url::Url;
+use write_parquet::{BrotliLevel, CompressionOptions, GzipLevel, ZstdLevel};
+
+use crate::internal_jni::utils::*;
+use crate::j_data_frame::JDataFrame;
+use crate::storage_config::StorageOptions;
+use crate::utils::write_utils::{
+    build_storage, ensure_write_mode, get_encodings, parse_json_to_storage_options,
+    parse_write_mode,
+};
+use crate::utils::{PathError, WriteModes};
+
+#[tokio::main(flavor = "current_thread")]
+async fn write_files(
+    object_store: &DynObjectStore,
+    prefix: Path,
+    url: Url,
+    write_opts: write_parquet::WriteOptions,
+    mut data_frame: DataFrame,
+    write_mode: WriteModes,
+) {
+    let meta = object_store.head(&prefix).await;
+    ensure_write_mode(meta, url, write_mode).expect("Error encountered");
+
+    data_frame.rechunk();
+
+    let schema = data_frame.schema().to_arrow();
+    let encodings = get_encodings(&schema);
+    let mut iter = data_frame.iter_chunks();
+
+    let (_id, writer) = object_store
+        .clone()
+        .put_multipart(&prefix.clone())
+        .await
+        .expect("Error encountered while opening destination");
+
+    let mut sink =
+        write_parquet::FileSink::try_new(writer.compat_write(), schema, encodings, write_opts)
+            .expect("Error encountered while creating file sink");
+
+    while let Some(chunk) = iter.next() {
+        sink.feed(chunk)
+            .await
+            .expect("Error encountered while feeding chunk")
+    }
+
+    sink.close()
+        .await
+        .expect("Error encountered while closing file sink");
+}
+
+#[jni_fn("org.polars.scala.polars.internal.jni.io.write$")]
+pub fn writeParquet(
+    env: JNIEnv,
+    _object: JObject,
+    df_ptr: jlong,
+    filePath: JString,
+    writeStats: jboolean,
+    compression: JString,
+    compressionLevel: jint,
+    options: JString,
+    writeMode: JString,
+) {
+    let this_path = get_file_path(env, filePath);
+
+    let compression_str = get_string(
+        env,
+        compression,
+        "Unable to get/ convert compression string to UTF8.",
+    );
+    let compression_level = if compressionLevel.is_negative() {
+        None
+    } else {
+        Some(compressionLevel as i32)
+    };
+
+    let compression = parse_parquet_compression(&compression_str, compression_level)
+        .expect("Unable to parse the provided compression argument(s)");
+
+    let write_mode_str = get_string(
+        env,
+        writeMode,
+        "Unable to get/ convert write mode string to UTF8.",
+    );
+
+    let write_mode = parse_write_mode(&write_mode_str)
+        .expect("Unable to parse the provided write mode argument");
+
+    let options: StorageOptions = parse_json_to_storage_options(env, options);
+
+    let write_options = write_parquet::WriteOptions {
+        write_statistics: writeStats == JNI_TRUE,
+        version: write_parquet::Version::V2,
+        compression,
+        data_pagesize_limit: None,
+    };
+
+    let j_df = unsafe { &mut *(df_ptr as *mut JDataFrame) };
+    let data_frame = j_df.to_owned().df;
+
+    let object_store = build_storage(this_path.clone(), options)
+        .expect("Unable to instantiate object store from provided path");
+
+    write_files(
+        object_store.storage.as_ref(),
+        object_store.path,
+        object_store.url,
+        write_options,
+        data_frame,
+        write_mode,
+    );
+}
+
+fn parse_parquet_compression(
+    compression: &str,
+    compression_level: Option<i32>,
+) -> Result<CompressionOptions, PathError> {
+    let parsed = match compression {
+        "uncompressed" => CompressionOptions::Uncompressed,
+
+        "snappy" => CompressionOptions::Snappy,
+
+        "lz4" => CompressionOptions::Lz4Raw,
+
+        "lzo" => CompressionOptions::Lzo,
+
+        "gzip" => CompressionOptions::Gzip(
+            compression_level
+                .map(|lvl| {
+                    GzipLevel::try_new(lvl as u8).map_err(|e| PathError::Generic(format!("{e:?}")))
+                })
+                .transpose()?,
+        ),
+
+        "brotli" => CompressionOptions::Brotli(
+            compression_level
+                .map(|lvl| {
+                    BrotliLevel::try_new(lvl as u32)
+                        .map_err(|e| PathError::Generic(format!("{e:?}")))
+                })
+                .transpose()?,
+        ),
+
+        "zstd" => CompressionOptions::Zstd(
+            compression_level
+                .map(|lvl| {
+                    ZstdLevel::try_new(lvl).map_err(|e| PathError::Generic(format!("{e:?}")))
+                })
+                .transpose()?,
+        ),
+
+        e => {
+            return Err(PathError::Generic(format!(
+                "Compression must be one of {{'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'lz4', 'zstd'}}, got {e}",
+            )));
+        }
+    };
+    Ok(parsed)
+}

--- a/native/src/internal_jni/utils.rs
+++ b/native/src/internal_jni/utils.rs
@@ -5,8 +5,37 @@ use jni::sys::{jint, jlong};
 use jni::JNIEnv;
 use polars::io::RowCount;
 use polars::prelude::*;
+use std::path::{Component, PathBuf};
 
 use crate::j_lazy_frame::JLazyFrame;
+
+pub fn normalize_path(path: &std::path::Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+
+    ret
+}
 
 pub fn get_string(env: JNIEnv, string: JString, error_msg: &str) -> String {
     env.get_string(string).expect(error_msg).into()

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -10,6 +10,8 @@ pub mod internal_jni;
 pub mod j_data_frame;
 pub mod j_expr;
 pub mod j_lazy_frame;
+mod storage_config;
+pub mod utils;
 
 const POLARS_VERSION: &str = "0.26.1";
 

--- a/native/src/storage_config.rs
+++ b/native/src/storage_config.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use object_store::aws::AmazonS3ConfigKey;
+use object_store::azure::AzureConfigKey;
+
+use object_store::gcp::GoogleConfigKey;
+use serde::{Deserialize, Serialize};
+
+/// Options used for configuring backend storage
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StorageOptions(pub HashMap<String, String>);
+
+pub(crate) fn str_is_truthy(val: &str) -> bool {
+    val.eq_ignore_ascii_case("1")
+        | val.eq_ignore_ascii_case("true")
+        | val.eq_ignore_ascii_case("on")
+        | val.eq_ignore_ascii_case("yes")
+        | val.eq_ignore_ascii_case("y")
+}
+
+impl StorageOptions {
+    /// Create a new instance of [`StorageOptions`]
+    pub fn new(options: HashMap<String, String>) -> Self {
+        let mut options = options;
+        if let Ok(value) = std::env::var("AZURE_STORAGE_ALLOW_HTTP") {
+            options.insert("allow_http".into(), value);
+        }
+        if let Ok(value) = std::env::var("AZURE_STORAGE_USE_HTTP") {
+            options.insert("allow_http".into(), value);
+        }
+        if let Ok(value) = std::env::var("AWS_STORAGE_ALLOW_HTTP") {
+            options.insert("allow_http".into(), value);
+        }
+        Self(options)
+    }
+
+    /// Denotes if unsecure connections via http are allowed
+    pub fn allow_http(&self) -> bool {
+        self.0.iter().any(|(key, value)| {
+            key.to_ascii_lowercase().contains("allow_http") & str_is_truthy(value)
+        })
+    }
+
+    /// Subset of options relevant for azure storage
+    pub fn as_azure_options(&self) -> HashMap<AzureConfigKey, String> {
+        self.0
+            .iter()
+            .filter_map(|(key, value)| {
+                let az_key = AzureConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
+                Some((az_key, value.clone()))
+            })
+            .collect()
+    }
+
+    /// Subset of options relevant for s3 storage
+    pub fn as_s3_options(&self) -> HashMap<AmazonS3ConfigKey, String> {
+        self.0
+            .iter()
+            .filter_map(|(key, value)| {
+                let s3_key = AmazonS3ConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
+                Some((s3_key, value.clone()))
+            })
+            .collect()
+    }
+
+    /// Subset of options relevant for gcs storage
+    pub fn as_gcs_options(&self) -> HashMap<GoogleConfigKey, String> {
+        self.0
+            .iter()
+            .filter_map(|(key, value)| {
+                let gcs_key = GoogleConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
+                Some((gcs_key, value.clone()))
+            })
+            .collect()
+    }
+}

--- a/native/src/storage_config.rs
+++ b/native/src/storage_config.rs
@@ -20,6 +20,11 @@ pub(crate) fn str_is_truthy(val: &str) -> bool {
 }
 
 impl StorageOptions {
+    pub fn fromJSON(json: String) -> Self {
+        let options_map: HashMap<String, String> = serde_json::from_str(&json).unwrap();
+        StorageOptions(options_map)
+    }
+
     /// Create a new instance of [`StorageOptions`]
     pub fn new(options: HashMap<String, String>) -> Self {
         let mut options = options;

--- a/native/src/utils/mod.rs
+++ b/native/src/utils/mod.rs
@@ -1,0 +1,19 @@
+pub mod write_utils;
+
+#[derive(thiserror::Error, Debug)]
+pub enum PathError {
+    #[error("Fatal error: {0}")]
+    Generic(String),
+
+    #[error("Cannot infer storage location from: {0}")]
+    InvalidTableLocation(String),
+
+    #[error("File already exists at the given location: {0}")]
+    FileAlreadyExists(String),
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub enum WriteModes {
+    ErrorIfExists,
+    Overwrite,
+}

--- a/native/src/utils/write_utils.rs
+++ b/native/src/utils/write_utils.rs
@@ -1,0 +1,183 @@
+use std::sync::Arc;
+
+use object_store::aws::AmazonS3Builder;
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::local::LocalFileSystem;
+use object_store::path::Path;
+use object_store::DynObjectStore;
+use polars::export::arrow::datatypes::PhysicalType;
+use polars::export::arrow::io::parquet::write::{transverse, Encoding};
+use polars::export::arrow::io::parquet::write::{
+    BrotliLevel, CompressionOptions, GzipLevel, ZstdLevel,
+};
+use polars::prelude::{ArrowDataType, ArrowSchema};
+use url::Url;
+
+use crate::internal_jni::utils::normalize_path;
+use crate::storage_config::StorageOptions;
+use crate::utils::{PathError, WriteModes};
+
+pub type ObjectStoreRef = Arc<DynObjectStore>;
+
+#[allow(unused)]
+#[derive(Debug, Clone)]
+pub struct PolarsObjectStore {
+    pub(crate) storage: ObjectStoreRef,
+    pub(crate) url: Url,
+    pub(crate) storage_options: StorageOptions,
+    pub(crate) path: Path,
+}
+
+pub fn build_storage(
+    path_str: String,
+    options: StorageOptions,
+) -> Result<PolarsObjectStore, PathError> {
+    let location = path_to_url(&path_str)?.clone();
+    let path = normalize_path(std::path::Path::new(location.path()));
+
+    let storage = get_object_store_ref(&(location.clone()), options.clone());
+
+    Ok(PolarsObjectStore {
+        storage: storage?,
+        url: location.clone(),
+        storage_options: options,
+        path: Path::from(path.to_string_lossy().as_ref()),
+    })
+}
+
+fn get_object_store_ref(
+    url: &Url,
+    options: impl Into<StorageOptions>,
+) -> Result<ObjectStoreRef, PathError> {
+    let _options = options.into();
+
+    match url.scheme() {
+        "file" => Ok(Arc::new(LocalFileSystem::new())),
+
+        "s3" | "s3a" => {
+            let store = AmazonS3Builder::from_env()
+                .with_url(url.as_ref())
+                .try_with_options(&_options.as_s3_options())
+                .unwrap()
+                .with_allow_http(_options.allow_http())
+                .build()
+                .unwrap();
+            Ok(Arc::new(store))
+        }
+
+        "az" | "abfs" | "abfss" | "azure" | "wasb" | "adl" => {
+            let store = MicrosoftAzureBuilder::from_env()
+                .with_url(url.as_ref())
+                .try_with_options(&_options.as_azure_options())
+                .unwrap()
+                .with_allow_http(_options.allow_http())
+                .build()
+                .unwrap();
+            Ok(Arc::new(store))
+        }
+
+        "gs" => {
+            let store = GoogleCloudStorageBuilder::from_env()
+                .with_url(url.as_ref())
+                .try_with_options(&_options.as_gcs_options())
+                .unwrap()
+                .build()
+                .unwrap();
+            Ok(Arc::new(store))
+        }
+
+        _ => Err(PathError::Generic(format!(
+            "unsupported url: {}",
+            url.as_str()
+        ))),
+    }
+}
+
+fn path_to_url(path_str: impl AsRef<str>) -> Result<Url, PathError> {
+    let path_str = path_str.as_ref();
+
+    if let Ok(url) = Url::parse(&path_str).or_else(|_| Url::from_file_path(path_str)) {
+        match url.scheme() {
+            "file" => Ok(url),
+            _ => Ok({
+                let mut new_url = url.clone();
+                new_url.set_path(url.path().trim_end_matches('/'));
+                new_url
+            }),
+        }
+    } else {
+        Err(PathError::InvalidTableLocation(path_str.to_string()))
+    }
+}
+
+fn encoding_map(data_type: &ArrowDataType) -> Encoding {
+    match data_type.to_physical_type() {
+        PhysicalType::Dictionary(_) => Encoding::RleDictionary,
+        // remaining is plain
+        _ => Encoding::Plain,
+    }
+}
+
+pub fn get_encodings(schema: &ArrowSchema) -> Vec<Vec<Encoding>> {
+    schema
+        .fields
+        .iter()
+        .map(|f| transverse(&f.data_type, encoding_map))
+        .collect()
+}
+
+pub fn parse_write_mode(write_mode: &str) -> Result<WriteModes, PathError> {
+    let parsed = match write_mode {
+        "Overwrite" => WriteModes::Overwrite,
+        _ => WriteModes::ErrorIfExists,
+    };
+    Ok(parsed)
+}
+
+pub fn parse_parquet_compression(
+    compression: &str,
+    compression_level: Option<i32>,
+) -> Result<CompressionOptions, PathError> {
+    let parsed = match compression {
+        "uncompressed" => CompressionOptions::Uncompressed,
+
+        "snappy" => CompressionOptions::Snappy,
+
+        "lz4" => CompressionOptions::Lz4Raw,
+
+        "lzo" => CompressionOptions::Lzo,
+
+        "gzip" => CompressionOptions::Gzip(
+            compression_level
+                .map(|lvl| {
+                    GzipLevel::try_new(lvl as u8).map_err(|e| PathError::Generic(format!("{e:?}")))
+                })
+                .transpose()?,
+        ),
+
+        "brotli" => CompressionOptions::Brotli(
+            compression_level
+                .map(|lvl| {
+                    BrotliLevel::try_new(lvl as u32)
+                        .map_err(|e| PathError::Generic(format!("{e:?}")))
+                })
+                .transpose()?,
+        ),
+
+        "zstd" => CompressionOptions::Zstd(
+            compression_level
+                .map(|lvl| {
+                    ZstdLevel::try_new(lvl).map_err(|e| PathError::Generic(format!("{e:?}")))
+                })
+                .transpose()?,
+        ),
+
+        e => {
+            return Err(PathError::Generic(format!(
+                "Compression must be one of {{'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'lz4', 'zstd'}}, got {e}",
+            )));
+        }
+    };
+    Ok(parsed)
+}


### PR DESCRIPTION
- Integrates object store on write path for destinations like s3, gcp, azure etc.
- Supports writing as parquet files
- Supports writing as Arrow IPC files
- Support for write modes like ErrorIfExists, Overwrite etc.
