### PR TITLE
Add method to convert a data frame to a JSON string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 .fleet/
 *.iml
 
+# VS Code specific
+.bloop
+.metals
+metals.sbt
+.vscode
+
 # SBT specific
 .bsp/
 coverage.xml

--- a/core/src/main/scala/org/polars/scala/polars/api/io/Writeable.scala
+++ b/core/src/main/scala/org/polars/scala/polars/api/io/Writeable.scala
@@ -156,6 +156,8 @@ class Writeable private[polars] (ptr: Long) {
     )
   }
 
-  def toJsonString(pretty: Boolean, rowOriented: Boolean): String = toJson(ptr, pretty, rowOriented)
+  def toJsonString(pretty: Boolean, rowOriented: Boolean): String = json(ptr, pretty, rowOriented)
+
+  def toJsonBytes(pretty: Boolean, rowOriented: Boolean): Array[Byte] = jsonBytes(ptr, pretty, rowOriented)
 
 }

--- a/core/src/main/scala/org/polars/scala/polars/api/io/Writeable.scala
+++ b/core/src/main/scala/org/polars/scala/polars/api/io/Writeable.scala
@@ -155,4 +155,7 @@ class Writeable private[polars] (ptr: Long) {
       writeMode = _mode
     )
   }
+
+  def toJsonString(pretty: Boolean, rowOriented: Boolean): String = toJson(ptr, pretty, rowOriented)
+
 }

--- a/core/src/main/scala/org/polars/scala/polars/internal/jni/io/write.scala
+++ b/core/src/main/scala/org/polars/scala/polars/internal/jni/io/write.scala
@@ -30,4 +30,6 @@ private[polars] object write extends Natively {
       writeMode: String
   ): Unit
 
+  @native def toJson(ptr: Long, pretty: Boolean, rowOriented: Boolean): String
+
 }

--- a/core/src/main/scala/org/polars/scala/polars/internal/jni/io/write.scala
+++ b/core/src/main/scala/org/polars/scala/polars/internal/jni/io/write.scala
@@ -30,6 +30,8 @@ private[polars] object write extends Natively {
       writeMode: String
   ): Unit
 
-  @native def toJson(ptr: Long, pretty: Boolean, rowOriented: Boolean): String
+  @native def json(ptr: Long, pretty: Boolean, rowOriented: Boolean): String
+
+  @native def jsonBytes(ptr: Long, pretty: Boolean, rowOriented: Boolean): Array[Byte]
 
 }

--- a/examples/src/main/scala/examples/scala/io/Json.scala
+++ b/examples/src/main/scala/examples/scala/io/Json.scala
@@ -38,6 +38,10 @@ object Json {
     val rowOriented = df.write().toJsonString(pretty = false, rowOriented = true)
     println(rowOriented)
 
+
+    println("Showing pretty column-oriented CSV file as a DataFrame to stdout.")
+    val prettyOrientedBytes = df.write().toJsonBytes(pretty = true, rowOriented = false)
+    println(new String(prettyOrientedBytes, "UTF-8"))
   }
 
 }

--- a/examples/src/main/scala/examples/scala/io/Json.scala
+++ b/examples/src/main/scala/examples/scala/io/Json.scala
@@ -1,0 +1,43 @@
+package examples.scala.io
+
+import org.polars.scala.polars.Polars
+import org.polars.scala.polars.api.DataFrame
+
+import examples.scala.utils.CommonUtils
+
+/** Polars supports exporting the contents of a [[DataFrame]] to JSON.
+  *
+  * It has 2 formats:
+  *   - a row-oriented format, which represents the frame as an array of objects whose keys are
+  *     the column names and whose values are the row’s corresponding values.
+  *   - a column-oriented format, which represents the frame as an array of objects containing a
+  *     column name, type, and the array of column values
+  *
+  * The column-oriented format may be pretty-printed. The row-oriented format is less efficient,
+  * but may be more convenient for downstream applications.
+  */
+object Json {
+
+  def main(args: Array[String]) = {
+
+    val path = CommonUtils.getResource("/files/web-ds/data.csv")
+    val df: DataFrame = Polars.csv.scan(path).collect
+
+    println("Showing CSV file as a DataFrame to stdout.")
+    df.show()
+
+    println("Showing column-oriented CSV file as a DataFrame to stdout.")
+    val colOriented = df.write().toJsonString(pretty = false, rowOriented = false)
+    println(colOriented)
+
+    println("Showing pretty column-oriented CSV file as a DataFrame to stdout.")
+    val prettyOriented = df.write().toJsonString(pretty = true, rowOriented = false)
+    println(prettyOriented)
+
+    println("Showing row column-oriented CSV file as a DataFrame to stdout.")
+    val rowOriented = df.write().toJsonString(pretty = false, rowOriented = true)
+    println(rowOriented)
+
+  }
+
+}

--- a/native/src/internal_jni/io/write/json.rs
+++ b/native/src/internal_jni/io/write/json.rs
@@ -1,0 +1,44 @@
+#![allow(non_snake_case)]
+
+use jni::objects::JObject;
+use jni::sys::{_jobject, jboolean, jlong};
+use jni::JNIEnv;
+use jni_fn::jni_fn;
+use polars::prelude::*;
+
+use crate::j_data_frame::JDataFrame;
+
+#[jni_fn("org.polars.scala.polars.internal.jni.io.write$")]
+pub fn toJson(
+    env: JNIEnv,
+    _object: JObject,
+    df_ptr: jlong,
+    pretty: jboolean,
+    row_oriented: jboolean,
+) -> *mut _jobject {
+    let j_df = unsafe { &mut *(df_ptr as *mut JDataFrame) };
+    let mut data_frame = j_df.to_owned().df;
+
+    let mut df = data_frame.as_single_chunk_par();
+
+    let mut buf: Vec<u8> = Vec::new();
+    match (pretty == 1, row_oriented == 1) {
+        (_, true) => JsonWriter::new(&mut buf)
+            .with_json_format(JsonFormat::Json)
+            .finish(&mut df),
+        (true, _) => serde_json::to_writer_pretty(&mut buf, &df)
+            .map_err(|e| polars_err!(ComputeError: "{e}")),
+        (false, _) => {
+            serde_json::to_writer(&mut buf, &df).map_err(|e| polars_err!(ComputeError: "{e}"))
+        },
+    }
+    .expect("Unable to format JSON");
+
+    let rust_string = String::from_utf8(buf).unwrap();
+
+    let output = env
+        .new_string(rust_string)
+        .expect("Couldn't create Java string!");
+
+    output.into_raw()
+}

--- a/native/src/internal_jni/io/write/mod.rs
+++ b/native/src/internal_jni/io/write/mod.rs
@@ -1,3 +1,4 @@
 pub mod avro;
 pub mod ipc;
+pub mod json;
 pub mod parquet;


### PR DESCRIPTION
Adds support for getting data out of a `DataFrame` as JSON.

The current `scala-polars` bindings appear to support file I/O, but I couldn't find a good way to load data in to a `DataFrame`, run some transformations, and then get the results back out for programmatic access. We'd be interested in working on ways to export columns of data as Scala `Vector` or `Array` data types as well, but this gets us started.

I welcome suggestions, as I'm a novice when it comes both to Polars and Rust.