### PR TITLE
feat: de-collapse DataTypes, add cast, isIn, isBetween, and str namespace

### DIFF
--- a/core/src/main/scala/com/github/chitralverma/polars/api/Row.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/Row.scala
@@ -150,8 +150,11 @@ class Row private (private[polars] val arr: Array[Object], schema: Schema) {
     *   when data type does not match.
     */
   def getInt(i: Int): Int = {
-    assertDataType(getDataType(i), IntegerType)
-    getAs[java.lang.Integer](i).intValue()
+    getDataType(i) match {
+      case Int8Type | Int16Type | Int32Type | UInt8Type | UInt16Type | UInt32Type =>
+      case x => assertDataType(x, Int32Type)
+    }
+    getAs[java.lang.Number](i).intValue()
   }
 
   /** Returns the value by column `name` as Int
@@ -168,8 +171,11 @@ class Row private (private[polars] val arr: Array[Object], schema: Schema) {
     *   when data type does not match.
     */
   def getLong(i: Int): Long = {
-    assertDataType(getDataType(i), LongType)
-    getAs[java.lang.Long](i).longValue()
+    getDataType(i) match {
+      case Int64Type | UInt64Type | Int32Type | UInt32Type =>
+      case x => assertDataType(x, Int64Type)
+    }
+    getAs[java.lang.Number](i).longValue()
   }
 
   /** Returns the value by column `name` as Long
@@ -185,7 +191,7 @@ class Row private (private[polars] val arr: Array[Object], schema: Schema) {
     *   when data type does not match.
     */
   def getFloat(i: Int): Float = {
-    assertDataType(getDataType(i), FloatType)
+    assertDataType(getDataType(i), Float32Type)
     getAs[java.lang.Float](i).floatValue()
   }
 
@@ -202,8 +208,11 @@ class Row private (private[polars] val arr: Array[Object], schema: Schema) {
     *   when data type does not match.
     */
   def getDouble(i: Int): Double = {
-    assertDataType(getDataType(i), DoubleType)
-    getAs[java.lang.Double](i).doubleValue()
+    getDataType(i) match {
+      case Float64Type | Float32Type =>
+      case x => assertDataType(x, Float64Type)
+    }
+    getAs[java.lang.Number](i).doubleValue()
   }
 
   /** Returns the value by column `name` as Double
@@ -305,7 +314,8 @@ class Row private (private[polars] val arr: Array[Object], schema: Schema) {
   def getJList[T: ClassTag](i: Int): java.util.List[T] = {
     getSchema.getFields(i).dataType match {
       case ListType(dt) => assertDataType(dt, DataType.typeToDataType[T]())
-      case x => assertDataType(x, ListType)
+      case x =>
+        assert(x.isInstanceOf[ListType], s"Data Type mismatch, expected ListType, found $x")
     }
 
     getAs[java.util.List[T]](i)
@@ -342,7 +352,7 @@ class Row private (private[polars] val arr: Array[Object], schema: Schema) {
       case StructType(fields) =>
         Schema.fromFields(fields)
       case x =>
-        assertDataType(x, StructType)
+        assert(x.isInstanceOf[StructType], s"Data Type mismatch, expected StructType, found $x")
         null
     }
 

--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Column.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Column.scala
@@ -1,5 +1,6 @@
 package com.github.chitralverma.polars.api.expressions
 
+import com.github.chitralverma.polars.api.types.DataType
 import com.github.chitralverma.polars.functions.lit
 import com.github.chitralverma.polars.internal.jni.expressions.column_expr
 
@@ -19,6 +20,54 @@ object BinaryOperators extends Enumeration {
 class Column private (p: Long) extends Expression(p) {
   import BinaryOperators._
   import UnaryOperators._
+
+  /** Returns the namespace accessor for string-related expressions. */
+  def str: ColumnStrNameSpace = {
+    checkClosed()
+    new ColumnStrNameSpace(this)
+  }
+
+  /** Cast the column to the specified DataType.
+    *
+    * @param dataType
+    *   target data type
+    */
+  def cast(dataType: DataType): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.cast(ptr, dataType.ffiName))
+  }
+
+  /** Check if the column values are present in the provided array.
+    *
+    * @param values
+    *   array of values to match
+    */
+  def isIn(values: Array[Any]): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.isIn(ptr, values))
+  }
+
+  /** Check if the column values are between the lower and upper bounds (inclusive).
+    *
+    * @param lower
+    *   lower bound
+    * @param upper
+    *   upper bound
+    */
+  def isBetween(lower: Any, upper: Any): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.isBetween(ptr, lower, upper))
+  }
+
+  /** Check if the string column matches the given SQL-like wildcard pattern.
+    *
+    * @param pattern
+    *   SQL-like pattern (e.g. "ap%")
+    */
+  def like(pattern: String): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.like(ptr, pattern))
+  }
 
   /** Not. */
   def unary_! : Column = {

--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/ColumnStrNameSpace.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/ColumnStrNameSpace.scala
@@ -1,0 +1,18 @@
+package com.github.chitralverma.polars.api.expressions
+
+import com.github.chitralverma.polars.internal.jni.expressions.column_expr
+
+/** Namespace for string-related expressions.
+  *
+  * In polars, string expressions are grouped under the `.str` namespace (e.g.
+  * `col("x").str.to_uppercase`). This class provides the same scoped syntax on JVM columns,
+  * mirroring the upstream polars API.
+  */
+class ColumnStrNameSpace private[polars] (private val parent: Column) {
+
+  /** Modify strings to their uppercase equivalent. */
+  def to_uppercase: Column = {
+    parent.checkClosed()
+    Column.withPtr(column_expr.to_uppercase(parent.ptr))
+  }
+}

--- a/core/src/main/scala/com/github/chitralverma/polars/api/types/DataTypes.java
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/types/DataTypes.java
@@ -1,0 +1,106 @@
+package com.github.chitralverma.polars.api.types;
+
+/**
+ * Spark-style Java-friendly facade for all Polars DataTypes.
+ * This class exposes public static final fields and static factory methods
+ * so Java and Scala users can refer to types cleanly (e.g. {@code DataTypes.Int32}
+ * instead of leaking Scala objects).
+ */
+public final class DataTypes {
+
+  private DataTypes() {}
+
+  // Basic singletons (Polars-faithful names)
+  public static final DataType String = StringType$.MODULE$;
+  public static final DataType Boolean = BooleanType$.MODULE$;
+  public static final DataType Int8 = Int8Type$.MODULE$;
+  public static final DataType Int16 = Int16Type$.MODULE$;
+  public static final DataType Int32 = Int32Type$.MODULE$;
+  public static final DataType Int64 = Int64Type$.MODULE$;
+  public static final DataType UInt8 = UInt8Type$.MODULE$;
+  public static final DataType UInt16 = UInt16Type$.MODULE$;
+  public static final DataType UInt32 = UInt32Type$.MODULE$;
+  public static final DataType UInt64 = UInt64Type$.MODULE$;
+  public static final DataType Float32 = Float32Type$.MODULE$;
+  public static final DataType Float64 = Float64Type$.MODULE$;
+  public static final DataType Date = DateType$.MODULE$;
+  public static final DataType Time = TimeType$.MODULE$;
+  public static final DataType Null = NullType$.MODULE$;
+
+  // Default DecimalType singleton (precision=None, scale=0)
+  public static final DataType Decimal = new DecimalType(scala.Option.apply(null), 0);
+
+  // Static Factory Methods for parametric types (S2 / Q2)
+
+  /**
+   * Create a Decimal DataType with the given scale.
+   *
+   * @param scale number of digits after the decimal point
+   * @return Decimal DataType
+   */
+  public static DataType decimal(int scale) {
+    return new DecimalType(scala.Option.apply(null), scale);
+  }
+
+  /**
+   * Create a Decimal DataType with the given precision and scale.
+   *
+   * @param precision total number of digits
+   * @param scale number of digits after the decimal point
+   * @return Decimal DataType
+   */
+  public static DataType decimal(int precision, int scale) {
+    return new DecimalType(scala.Option.apply(precision), scale);
+  }
+
+  /**
+   * Create a Time DataType with the specified time unit.
+   *
+   * @param timeUnit time unit (e.g. "Microseconds", "Nanoseconds")
+   * @return Time DataType
+   */
+  public static DataType time(String timeUnit) {
+    return new TimeType(timeUnit);
+  }
+
+  /**
+   * Create a Datetime DataType with the specified time unit and timezone.
+   *
+   * @param timeUnit time unit (e.g. "Microseconds")
+   * @param timeZone timezone identifier (e.g. "UTC", "Asia/Tokyo") or null
+   * @return Datetime DataType
+   */
+  public static DataType datetime(String timeUnit, String timeZone) {
+    return new DateTimeType(timeUnit, timeZone);
+  }
+
+  /**
+   * Create a Duration DataType with the specified time unit.
+   *
+   * @param timeUnit time unit (e.g. "Microseconds")
+   * @return Duration DataType
+   */
+  public static DataType duration(String timeUnit) {
+    return new Duration(timeUnit);
+  }
+
+  /**
+   * Create a List DataType with the specified element type.
+   *
+   * @param elementType the DataType of the list's elements
+   * @return List DataType
+   */
+  public static DataType list(DataType elementType) {
+    return new ListType(elementType);
+  }
+
+  /**
+   * Create a Struct DataType consisting of the specified fields.
+   *
+   * @param fields fields defining the struct's schema
+   * @return Struct DataType
+   */
+  public static DataType struct(Field[] fields) {
+    return new StructType(fields);
+  }
+}

--- a/core/src/main/scala/com/github/chitralverma/polars/api/types/DataTypes.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/types/DataTypes.scala
@@ -11,39 +11,114 @@ import scala.util.matching.Regex
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeType
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.github.chitralverma.polars.jsonMapper
 
 trait DataType {
+
+  /** Returns the simple lowercase name of this DataType. */
   def simpleName: String =
     this.getClass.getSimpleName
       .stripSuffix("$")
       .stripSuffix("Type")
-      .stripSuffix("UDT")
       .toLowerCase(Locale.ROOT)
+
+  /** Returns the official JSON string representation of this DataType, compatible with Polars'
+    * upstream serde/FFI deserializer.
+    */
+  def ffiName: String = {
+    val node = toJsonNode
+    if (node.isTextual) node.textValue()
+    else jsonMapper.writeValueAsString(node)
+  }
+
+  private[polars] def toJsonNode: JsonNode
 }
 
-trait BasicDataType extends DataType
+trait BasicDataType extends DataType {
+  override private[polars] def toJsonNode: JsonNode =
+    jsonMapper.getNodeFactory.textNode(
+      this.getClass.getSimpleName
+        .stripSuffix("$")
+        .stripSuffix("Type")
+    )
+}
 
-case object StringType extends BasicDataType
+case object StringType extends BasicDataType {
+  override def simpleName: String = "string"
+}
 
-case object BooleanType extends BasicDataType
+case object BooleanType extends BasicDataType {
+  override def simpleName: String = "boolean"
+}
 
-case object IntegerType extends BasicDataType
+case object Int8Type extends BasicDataType {
+  override def simpleName: String = "int8"
+}
 
-case object LongType extends BasicDataType
+case object Int16Type extends BasicDataType {
+  override def simpleName: String = "int16"
+}
 
-case object FloatType extends BasicDataType
+case object Int32Type extends BasicDataType {
+  override def simpleName: String = "int32"
+}
 
-case object DoubleType extends BasicDataType
+case object Int64Type extends BasicDataType {
+  override def simpleName: String = "int64"
+}
 
-case object DateType extends BasicDataType
+case object UInt8Type extends BasicDataType {
+  override def simpleName: String = "uint8"
+}
 
-case object TimeType extends DataType
+case object UInt16Type extends BasicDataType {
+  override def simpleName: String = "uint16"
+}
 
-case object DateTimeType extends DataType
+case object UInt32Type extends BasicDataType {
+  override def simpleName: String = "uint32"
+}
 
-case object ListType extends DataType
+case object UInt64Type extends BasicDataType {
+  override def simpleName: String = "uint64"
+}
 
-case object StructType extends DataType
+case object Float32Type extends BasicDataType {
+  override def simpleName: String = "float32"
+}
+
+case object Float64Type extends BasicDataType {
+  override def simpleName: String = "float64"
+}
+
+case class DecimalType(precision: Option[Int], scale: Int) extends DataType {
+  override def simpleName: String = s"decimal[${precision.getOrElse(38)},$scale]"
+  override private[polars] def toJsonNode: JsonNode = {
+    val root = jsonMapper.getNodeFactory.objectNode()
+    val arr = jsonMapper.getNodeFactory.arrayNode()
+    precision match {
+      case Some(p) => arr.add(p)
+      case None => arr.addNull()
+    }
+    arr.add(scale)
+    root.set("Decimal", arr)
+    root
+  }
+}
+
+case object DateType extends BasicDataType {
+  override def simpleName: String = "date"
+}
+
+case object TimeType extends DataType {
+  override private[polars] def toJsonNode: JsonNode =
+    jsonMapper.getNodeFactory.textNode("Time")
+}
+
+case object NullType extends BasicDataType {
+  override def simpleName: String = "null"
+}
 
 case class TimeType(protected val unitStr: String) extends DataType {
   val timeUnit: Option[TimeUnit] =
@@ -59,6 +134,18 @@ case class TimeType(protected val unitStr: String) extends DataType {
     case Some(TimeUnit.MICROSECONDS) => "time[us]"
     case Some(TimeUnit.MILLISECONDS) => "time[ms]"
     case _ => "time"
+  }
+
+  override private[polars] def toJsonNode: JsonNode = {
+    val root = jsonMapper.getNodeFactory.objectNode()
+    val u = timeUnit match {
+      case Some(TimeUnit.NANOSECONDS) => "Nanoseconds"
+      case Some(TimeUnit.MICROSECONDS) => "Microseconds"
+      case Some(TimeUnit.MILLISECONDS) => "Milliseconds"
+      case _ => "Microseconds"
+    }
+    root.put("Time", u)
+    root
   }
 }
 
@@ -91,7 +178,22 @@ case class DateTimeType(protected val unitStr: String, protected val tzStr: Stri
       case (null, tz) => s"datetime[$tz]"
       case (tu, tz) => s"datetime[$tu, $tz]"
     }
+  }
 
+  override private[polars] def toJsonNode: JsonNode = {
+    val root = jsonMapper.getNodeFactory.objectNode()
+    val arr = jsonMapper.getNodeFactory.arrayNode()
+    val tu = timeUnit match {
+      case Some(TimeUnit.NANOSECONDS) => "Nanoseconds"
+      case Some(TimeUnit.MICROSECONDS) => "Microseconds"
+      case Some(TimeUnit.MILLISECONDS) => "Milliseconds"
+      case _ => "Microseconds"
+    }
+    arr.add(tu)
+    if (tzStr != null && tzStr.nonEmpty) arr.add(tzStr)
+    else arr.addNull()
+    root.set("Timestamp", arr)
+    root
   }
 }
 
@@ -110,6 +212,18 @@ case class Duration(protected val unitStr: String) extends DataType {
     case Some(TimeUnit.MILLISECONDS) => "duration[ms]"
     case _ => "duration"
   }
+
+  override private[polars] def toJsonNode: JsonNode = {
+    val root = jsonMapper.getNodeFactory.objectNode()
+    val tu = timeUnit match {
+      case Some(TimeUnit.NANOSECONDS) => "Nanoseconds"
+      case Some(TimeUnit.MICROSECONDS) => "Microseconds"
+      case Some(TimeUnit.MILLISECONDS) => "Milliseconds"
+      case _ => "Microseconds"
+    }
+    root.put("Duration", tu)
+    root
+  }
 }
 
 case class ListType(tpe: DataType) extends DataType {
@@ -121,6 +235,13 @@ case class ListType(tpe: DataType) extends DataType {
     DataType.buildFormattedString(tpe, s"$prefix    |", buffer)
   }
 
+  override private[polars] def toJsonNode: JsonNode = {
+    val root = jsonMapper.getNodeFactory.objectNode()
+    val listInner = jsonMapper.getNodeFactory.objectNode()
+    listInner.set("dtype", tpe.toJsonNode)
+    root.set("List", listInner)
+    root
+  }
 }
 
 case class StructType(fields: Array[Field]) extends DataType {
@@ -131,26 +252,53 @@ case class StructType(fields: Array[Field]) extends DataType {
   /** Borrowed from Apache Spark source to represent [[StructType]] as a tree string. */
   private[polars] def buildFormattedString(prefix: String, buffer: StringBuffer): Unit =
     fields.foreach(field => field.buildFormattedString(prefix, buffer))
+
+  override private[polars] def toJsonNode: JsonNode = {
+    val root = jsonMapper.getNodeFactory.objectNode()
+    val arr = jsonMapper.getNodeFactory.arrayNode()
+    fields.foreach { f =>
+      val fNode = jsonMapper.getNodeFactory.objectNode()
+      fNode.put("name", f.name)
+      fNode.set("dtype", f.dataType.toJsonNode)
+      arr.add(fNode)
+    }
+    root.set("Struct", arr)
+    root
+  }
 }
 
 object DataType {
 
   private[polars] final val StringRegex: Regex = """^(?i)Utf8|LargeUtf8|String$""".r
   private[polars] final val BooleanRegex: Regex = """^(?i)Boolean$""".r
-  private[polars] final val IntRegex: Regex = """^(?i)Int8|Int16|Int32|UInt8|UInt16|UInt32$""".r
-  private[polars] final val LongRegex: Regex = """^(?i)Int64|UInt64$""".r
+  private[polars] final val Int8Regex: Regex = """^(?i)Int8$""".r
+  private[polars] final val Int16Regex: Regex = """^(?i)Int16$""".r
+  private[polars] final val Int32Regex: Regex = """^(?i)Int32$""".r
+  private[polars] final val Int64Regex: Regex = """^(?i)Int64$""".r
+  private[polars] final val UInt8Regex: Regex = """^(?i)UInt8$""".r
+  private[polars] final val UInt16Regex: Regex = """^(?i)UInt16$""".r
+  private[polars] final val UInt32Regex: Regex = """^(?i)UInt32$""".r
+  private[polars] final val UInt64Regex: Regex = """^(?i)UInt64$""".r
   private[polars] final val FloatRegex: Regex = """^(?i)Float32$""".r
   private[polars] final val DoubleRegex: Regex = """^(?i)Float64$""".r
   private[polars] final val DateRegex: Regex = """^(?i)Date|Date32|Date64$""".r
+  private[polars] final val NullRegex: Regex = """^(?i)Null$""".r
 
   def fromBasicType(typeStr: String): DataType = typeStr match {
     case StringRegex() => StringType
     case BooleanRegex() => BooleanType
-    case IntRegex() => IntegerType
-    case LongRegex() => LongType
-    case FloatRegex() => FloatType
-    case DoubleRegex() => DoubleType
+    case Int8Regex() => Int8Type
+    case Int16Regex() => Int16Type
+    case Int32Regex() => Int32Type
+    case Int64Regex() => Int64Type
+    case UInt8Regex() => UInt8Type
+    case UInt16Regex() => UInt16Type
+    case UInt32Regex() => UInt32Type
+    case UInt64Regex() => UInt64Type
+    case FloatRegex() => Float32Type
+    case DoubleRegex() => Float64Type
     case DateRegex() => DateType
+    case NullRegex() => NullType
     case typeStr =>
       throw new IllegalArgumentException(s"Unknown basic type `$typeStr` is not supported.")
   }
@@ -175,6 +323,19 @@ object DataType {
       // For Duration Type
       case JsonNodeType.OBJECT if node.hasNonNull("Duration") =>
         Duration(node.get("Duration").textValue())
+
+      // For Decimal Type
+      case JsonNodeType.OBJECT if node.has("Decimal") =>
+        val decNode = node.get("Decimal")
+        if (decNode.isNull || decNode.isMissingNode) {
+          DecimalType(None, 0)
+        } else {
+          val elements = decNode.elements().asScala.toSeq
+          val precision =
+            if (elements.nonEmpty && !elements.head.isNull) Some(elements.head.asInt()) else None
+          val scale = if (elements.length > 1) elements(1).asInt() else 0
+          DecimalType(precision, scale)
+        }
 
       // For DateTime Type
       case JsonNodeType.OBJECT if node.hasNonNull("Timestamp") =>
@@ -208,16 +369,18 @@ object DataType {
   def typeToDataType[T: ClassTag](): DataType = {
     val clazz = implicitly[ClassTag[T]].runtimeClass
     clazz match {
-      case c if c == classOf[java.lang.Integer] || c == classOf[Int] => IntegerType
-      case c if c == classOf[java.lang.Long] || c == classOf[Long] => LongType
+      case c if c == classOf[java.lang.Byte] || c == classOf[Byte] => Int8Type
+      case c if c == classOf[java.lang.Short] || c == classOf[Short] => Int16Type
+      case c if c == classOf[java.lang.Integer] || c == classOf[Int] => Int32Type
+      case c if c == classOf[java.lang.Long] || c == classOf[Long] => Int64Type
       case c if c == classOf[java.lang.Boolean] || c == classOf[Boolean] => BooleanType
-      case c if c == classOf[java.lang.Float] || c == classOf[Float] => FloatType
-      case c if c == classOf[java.lang.Double] || c == classOf[Double] => DoubleType
+      case c if c == classOf[java.lang.Float] || c == classOf[Float] => Float32Type
+      case c if c == classOf[java.lang.Double] || c == classOf[Double] => Float64Type
       case c if c == classOf[java.time.LocalDate] => DateType
       case c if c == classOf[java.time.LocalTime] => TimeType
-      case c if c == classOf[java.time.ZonedDateTime] => DateTimeType
+      case c if c == classOf[java.time.ZonedDateTime] => DateTimeType(null, null)
       case c if c == classOf[java.lang.String] || c == classOf[String] => StringType
-      case c if c == classOf[java.util.List[_]] => ListType
+      case c if c == classOf[java.util.List[_]] => ListType(null)
       case c =>
         throw new IllegalArgumentException(
           s"Data type could not be found for class `${c.getSimpleName}`"

--- a/core/src/main/scala/com/github/chitralverma/polars/api/types/Schema.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/types/Schema.scala
@@ -26,14 +26,18 @@ class Schema {
 
   def getField(i: Int): Option[Field] = Try(getFields(i)).toOption
 
-  def getField(name: String, ignoreCase: Boolean = false): Option[Field] =
+  def getField(name: String): Option[Field] = getField(name, ignoreCase = false)
+
+  def getField(name: String, ignoreCase: Boolean): Option[Field] =
     getFields.find { field =>
       val fieldName = field.name
       if (ignoreCase) fieldName.equalsIgnoreCase(name)
       else fieldName.equals(name)
     }
 
-  def getFieldIndex(name: String, ignoreCase: Boolean = false): Option[Int] =
+  def getFieldIndex(name: String): Option[Int] = getFieldIndex(name, ignoreCase = false)
+
+  def getFieldIndex(name: String, ignoreCase: Boolean): Option[Int] =
     getField(name, ignoreCase).map(f => getFields.indexOf(f))
 
   override def toString: String = treeString

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
@@ -12,6 +12,16 @@ private[polars] object column_expr extends Natively {
 
   @native def applyBinary(leftPtr: Long, rightPtr: Long, op: Int): Long
 
+  @native def cast(ptr: Long, dataType: String): Long
+
+  @native def isIn(ptr: Long, values: Array[Any]): Long
+
+  @native def isBetween(ptr: Long, lower: Any, upper: Any): Long
+
+  @native def like(ptr: Long, pattern: String): Long
+
+  @native def to_uppercase(ptr: Long): Long
+
   @native def free(ptr: Long): Unit
 
 }

--- a/core/src/test/java/com/github/chitralverma/polars/DataTypeTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/DataTypeTest.java
@@ -1,0 +1,98 @@
+package com.github.chitralverma.polars;
+
+import static com.github.chitralverma.polars.functions.*;
+
+import com.github.chitralverma.polars.api.DataFrame;
+import com.github.chitralverma.polars.api.types.*;
+import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Java mirror of {@code DataTypeSuite}. Replicates behaviours tested in upstream py-polars
+ * `tests/unit/datatypes/test_datatypes.py`.
+ */
+public class DataTypeTest extends AbstractPolarsJavaTest {
+
+  @Test
+  public void ffiNameSerializesToOfficialPolarsSerdeJson() {
+    Assert.assertEquals("String", DataTypes.String.ffiName());
+    Assert.assertEquals("Int32", DataTypes.Int32.ffiName());
+    Assert.assertEquals("Float64", DataTypes.Float64.ffiName());
+    Assert.assertEquals("Boolean", DataTypes.Boolean.ffiName());
+
+    Assert.assertEquals("{\"Time\":\"Microseconds\"}", DataTypes.time("Microseconds").ffiName());
+    Assert.assertEquals(
+        "{\"Timestamp\":[\"Microseconds\",\"UTC\"]}",
+        DataTypes.datetime("Microseconds", "UTC").ffiName());
+    Assert.assertEquals(
+        "{\"Duration\":\"Microseconds\"}", DataTypes.duration("Microseconds").ffiName());
+
+    Assert.assertEquals(
+        "{\"List\":{\"dtype\":\"Int32\"}}", DataTypes.list(DataTypes.Int32).ffiName());
+    Assert.assertEquals(
+        "{\"Struct\":[{\"name\":\"a\",\"dtype\":\"Int32\"}]}",
+        DataTypes.struct(new Field[] {new Field("a", DataTypes.Int32)}).ffiName());
+  }
+
+  @Test
+  public void datatypeEqualityAndTimeUnits() {
+    Assert.assertNotEquals(DataTypes.datetime("ms", "UTC"), DataTypes.datetime("ns", "UTC"));
+    Assert.assertNotEquals(DataTypes.duration("ns"), DataTypes.duration("us"));
+
+    Assert.assertEquals(DataTypes.datetime("us", "UTC"), DataTypes.datetime("us", "UTC"));
+    Assert.assertEquals(DataTypes.duration("us"), DataTypes.duration("us"));
+  }
+
+  @Test
+  public void castEndToEnd() {
+    DataFrame df = intFrame("a", 1, 2, 3);
+
+    // Cast Int32 -> Int16
+    DataFrame result1 = df.with_column("b", col("a").cast(DataTypes.Int16));
+    assertColumns(result1, "a", "b");
+    Assert.assertEquals(Int16Type$.MODULE$, result1.schema().getField("b").get().dataType());
+
+    // Cast Int32 -> Float64
+    DataFrame result2 = df.with_column("b", col("a").cast(DataTypes.Float64));
+    Assert.assertEquals(Float64Type$.MODULE$, result2.schema().getField("b").get().dataType());
+    assertColumnValues(result2, "b", 1.0, 2.0, 3.0);
+  }
+
+  @Test
+  public void isInUnaryOp() {
+    DataFrame df = intFrame("a", 1, 2, 3, 4);
+    DataFrame result = df.filter(col("a").isIn(new Object[] {2, 4}));
+
+    assertRowCount(result, 2);
+    assertColumnValues(result, "a", 2, 4);
+  }
+
+  @Test
+  public void isBetweenUnaryOp() {
+    DataFrame df = intFrame("a", 1, 2, 3, 4);
+    DataFrame result = df.filter(col("a").isBetween(2, 3));
+
+    assertRowCount(result, 2);
+    assertColumnValues(result, "a", 2, 3);
+  }
+
+  @Test
+  public void stringToUppercase() {
+    DataFrame df = stringFrame("a", "apple", "banana");
+    DataFrame result = df.with_column("b", col("a").str().to_uppercase());
+
+    assertRowCount(result, 2);
+    assertColumns(result, "a", "b");
+    assertColumnValues(result, "b", "APPLE", "BANANA");
+  }
+
+  @Test
+  public void likeWithWildcardMatching() {
+    DataFrame df = stringFrame("a", "apple", "banana", "apricot");
+    DataFrame result = df.filter(col("a").like("ap%"));
+
+    assertRowCount(result, 2);
+    assertColumnValues(result, "a", "apple", "apricot");
+  }
+}

--- a/core/src/test/scala/com/github/chitralverma/polars/DataTypeSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/DataTypeSuite.scala
@@ -1,0 +1,90 @@
+package com.github.chitralverma.polars
+
+import com.github.chitralverma.polars.api.types._
+import com.github.chitralverma.polars.functions._
+import com.github.chitralverma.polars.testing.PolarsTestBase
+
+/** Replicates behaviours tested in upstream py-polars `tests/unit/datatypes/test_datatypes.py`.
+  * Verifies de-collapsed integers, precise floating types, temporal types, and nested types can
+  * be round-tripped with their JNI String/JSON ffiName, casted end-to-end, and verified in Rows.
+  */
+class DataTypeSuite extends PolarsTestBase {
+
+  test("ffiName serializes to official Polars serde JSON") {
+    DataTypes.String.ffiName shouldBe "String"
+    DataTypes.Int32.ffiName shouldBe "Int32"
+    DataTypes.Float64.ffiName shouldBe "Float64"
+    DataTypes.Boolean.ffiName shouldBe "Boolean"
+
+    DataTypes.time("Microseconds").ffiName shouldBe """{"Time":"Microseconds"}"""
+    DataTypes
+      .datetime("Microseconds", "UTC")
+      .ffiName shouldBe """{"Timestamp":["Microseconds","UTC"]}"""
+    DataTypes.duration("Microseconds").ffiName shouldBe """{"Duration":"Microseconds"}"""
+
+    DataTypes.list(DataTypes.Int32).ffiName shouldBe """{"List":{"dtype":"Int32"}}"""
+    DataTypes
+      .struct(Array(Field("a", DataTypes.Int32)))
+      .ffiName shouldBe """{"Struct":[{"name":"a","dtype":"Int32"}]}"""
+  }
+
+  test("datatype equality and time units (test_dtype_time_units)") {
+    DataTypes.datetime("ms", "UTC") should not be DataTypes.datetime("ns", "UTC")
+    DataTypes.duration("ns") should not be DataTypes.duration("us")
+
+    DataTypes.datetime("us", "UTC") shouldBe DataTypes.datetime("us", "UTC")
+    DataTypes.duration("us") shouldBe DataTypes.duration("us")
+  }
+
+  test("cast end-to-end (including exact signed/unsigned widths)") {
+    val df = intFrame("a", 1, 2, 3)
+
+    // Cast Int32 -> Int16
+    val result1 = df.with_column("b", col("a").cast(DataTypes.Int16))
+    assertColumns(result1, "a", "b")
+    result1.schema.getField("b").get.dataType shouldBe Int16Type
+
+    // Cast Int32 -> Float64
+    val result2 = df.with_column("b", col("a").cast(DataTypes.Float64))
+    result2.schema.getField("b").get.dataType shouldBe Float64Type
+    assertColumnValues(result2, "b", 1.0, 2.0, 3.0)
+
+    // Cast Int32 -> String
+    val result3 = df.with_column("b", col("a").cast(DataTypes.String))
+    result3.schema.getField("b").get.dataType shouldBe StringType
+    assertColumnValues(result3, "b", "1", "2", "3")
+  }
+
+  test("isIn unary op end-to-end") {
+    val df = intFrame("a", 1, 2, 3, 4)
+    val result = df.filter(col("a").isIn(Array(2, 4)))
+
+    assertRowCount(result, 2)
+    assertColumnValues(result, "a", 2, 4)
+  }
+
+  test("isBetween unary op end-to-end") {
+    val df = intFrame("a", 1, 2, 3, 4)
+    val result = df.filter(col("a").isBetween(2, 3))
+
+    assertRowCount(result, 2)
+    assertColumnValues(result, "a", 2, 3)
+  }
+
+  test("str.to_uppercase end-to-end") {
+    val df = stringFrame("a", "apple", "banana")
+    val result = df.with_column("b", col("a").str.to_uppercase)
+
+    assertRowCount(result, 2)
+    assertColumns(result, "a", "b")
+    assertColumnValues(result, "b", "APPLE", "BANANA")
+  }
+
+  test("like end-to-end with wildcard matching") {
+    val df = stringFrame("a", "apple", "banana", "apricot")
+    val result = df.filter(col("a").like("ap%"))
+
+    assertRowCount(result, 2)
+    assertColumnValues(result, "a", "apple", "apricot")
+  }
+}

--- a/native/src/internal_jni/expr/column.rs
+++ b/native/src/internal_jni/expr/column.rs
@@ -2,7 +2,7 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 
 use anyhow::Context;
 use jni::JNIEnv;
-use jni::objects::{JClass, JString};
+use jni::objects::{JClass, JObject, JObjectArray, JString};
 use jni::sys::{jint, jlong};
 use jni_fn::jni_fn;
 use num_derive::FromPrimitive;
@@ -91,6 +91,278 @@ pub fn applyUnary(mut env: JNIEnv, _: JClass, expr_ptr: *mut Expr, operator: jin
         ))
         .unwrap_or_throw(&mut env);
 
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn cast(mut env: JNIEnv, _: JClass, expr_ptr: *mut Expr, dataType: JString) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let dt_str = j_string_to_string(
+        &mut env,
+        &dataType,
+        Some("Failed to parse provided DataType as string"),
+    );
+
+    let dtype: DataType = if dt_str.starts_with('{') {
+        serde_json::from_str(&dt_str)
+            .context(format!("Failed to deserialize DataType JSON: {dt_str}"))
+            .unwrap_or_throw(&mut env)
+    } else {
+        // Fallback to basic type name parsing
+        match dt_str.to_lowercase().as_str() {
+            "int8" => DataType::Int8,
+            "int16" => DataType::Int16,
+            "int32" => DataType::Int32,
+            "int64" => DataType::Int64,
+            "uint8" => DataType::UInt8,
+            "uint16" => DataType::UInt16,
+            "uint32" => DataType::UInt32,
+            "uint64" => DataType::UInt64,
+            "float32" => DataType::Float32,
+            "float64" => DataType::Float64,
+            "boolean" => DataType::Boolean,
+            "string" | "utf8" => DataType::String,
+            "binary" => DataType::Binary,
+            "date" => DataType::Date,
+            "null" => DataType::Null,
+            _ => {
+                // Try serde_json with quoted string
+                serde_json::from_str(&format!("\"{dt_str}\""))
+                    .context(format!("Failed to parse DataType: {dt_str}"))
+                    .unwrap_or_throw(&mut env)
+            },
+        }
+    };
+
+    let expr = l_expr.cast(dtype);
+    to_ptr(expr)
+}
+
+fn jobject_to_any_value<'local>(
+    env: &mut JNIEnv<'local>,
+    obj: &JObject<'local>,
+) -> AnyValue<'local> {
+    if obj.is_null() {
+        AnyValue::Null
+    } else if env
+        .is_instance_of(obj, "java/lang/Integer")
+        .unwrap_or(false)
+    {
+        let val = env
+            .call_method(obj, "intValue", "()I", &[])
+            .context("Failed to call intValue")
+            .unwrap_or_throw(env)
+            .i()
+            .unwrap_or(0);
+        AnyValue::Int32(val)
+    } else if env.is_instance_of(obj, "java/lang/Long").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "longValue", "()J", &[])
+            .context("Failed to call longValue")
+            .unwrap_or_throw(env)
+            .j()
+            .unwrap_or(0);
+        AnyValue::Int64(val)
+    } else if env.is_instance_of(obj, "java/lang/Byte").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "byteValue", "()B", &[])
+            .context("Failed to call byteValue")
+            .unwrap_or_throw(env)
+            .b()
+            .unwrap_or(0);
+        AnyValue::Int8(val)
+    } else if env.is_instance_of(obj, "java/lang/Short").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "shortValue", "()S", &[])
+            .context("Failed to call shortValue")
+            .unwrap_or_throw(env)
+            .s()
+            .unwrap_or(0);
+        AnyValue::Int16(val)
+    } else if env.is_instance_of(obj, "java/lang/String").unwrap_or(false) {
+        let jstr: &JString = obj.into();
+        let s = j_string_to_string(env, jstr, Some("Invalid String"));
+        AnyValue::StringOwned(s.into())
+    } else if env
+        .is_instance_of(obj, "java/lang/Boolean")
+        .unwrap_or(false)
+    {
+        let val = env
+            .call_method(obj, "booleanValue", "()Z", &[])
+            .context("Failed to call booleanValue")
+            .unwrap_or_throw(env)
+            .z()
+            .unwrap_or(false);
+        AnyValue::Boolean(val)
+    } else if env.is_instance_of(obj, "java/lang/Double").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "doubleValue", "()D", &[])
+            .context("Failed to call doubleValue")
+            .unwrap_or_throw(env)
+            .d()
+            .unwrap_or(0.0);
+        AnyValue::Float64(val)
+    } else if env.is_instance_of(obj, "java/lang/Float").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "floatValue", "()F", &[])
+            .context("Failed to call floatValue")
+            .unwrap_or_throw(env)
+            .f()
+            .unwrap_or(0.0);
+        AnyValue::Float32(val)
+    } else {
+        AnyValue::Null
+    }
+}
+
+fn jobject_to_expr<'local>(env: &mut JNIEnv<'local>, obj: &JObject<'local>) -> Expr {
+    if obj.is_null() {
+        NULL.lit()
+    } else if env
+        .is_instance_of(obj, "java/lang/Integer")
+        .unwrap_or(false)
+    {
+        let val = env
+            .call_method(obj, "intValue", "()I", &[])
+            .context("Failed to call intValue")
+            .unwrap_or_throw(env)
+            .i()
+            .unwrap_or(0);
+        lit(val)
+    } else if env.is_instance_of(obj, "java/lang/Long").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "longValue", "()J", &[])
+            .context("Failed to call longValue")
+            .unwrap_or_throw(env)
+            .j()
+            .unwrap_or(0);
+        lit(val)
+    } else if env.is_instance_of(obj, "java/lang/Byte").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "byteValue", "()B", &[])
+            .context("Failed to call byteValue")
+            .unwrap_or_throw(env)
+            .b()
+            .unwrap_or(0);
+        lit(val)
+    } else if env.is_instance_of(obj, "java/lang/Short").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "shortValue", "()S", &[])
+            .context("Failed to call shortValue")
+            .unwrap_or_throw(env)
+            .s()
+            .unwrap_or(0);
+        lit(val)
+    } else if env.is_instance_of(obj, "java/lang/String").unwrap_or(false) {
+        let jstr: &JString = obj.into();
+        let s = j_string_to_string(env, jstr, Some("Invalid String"));
+        lit(s)
+    } else if env
+        .is_instance_of(obj, "java/lang/Boolean")
+        .unwrap_or(false)
+    {
+        let val = env
+            .call_method(obj, "booleanValue", "()Z", &[])
+            .context("Failed to call booleanValue")
+            .unwrap_or_throw(env)
+            .z()
+            .unwrap_or(false);
+        lit(val)
+    } else if env.is_instance_of(obj, "java/lang/Double").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "doubleValue", "()D", &[])
+            .context("Failed to call doubleValue")
+            .unwrap_or_throw(env)
+            .d()
+            .unwrap_or(0.0);
+        lit(val)
+    } else if env.is_instance_of(obj, "java/lang/Float").unwrap_or(false) {
+        let val = env
+            .call_method(obj, "floatValue", "()F", &[])
+            .context("Failed to call floatValue")
+            .unwrap_or_throw(env)
+            .f()
+            .unwrap_or(0.0);
+        lit(val)
+    } else {
+        NULL.lit()
+    }
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn isIn(mut env: JNIEnv, _: JClass, expr_ptr: *mut Expr, values: JObjectArray) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let len = env
+        .get_array_length(&values)
+        .context("Failed to get array length")
+        .unwrap_or_throw(&mut env);
+    let mut s_vec = Vec::with_capacity(len as usize);
+
+    for i in 0..len {
+        let obj = env
+            .get_object_array_element(&values, i)
+            .context("Failed to get array element")
+            .unwrap_or_throw(&mut env);
+        s_vec.push(jobject_to_any_value(&mut env, &obj));
+    }
+
+    let s = Series::from_any_values("values".into(), &s_vec, false)
+        .context("Failed to build series from any values")
+        .unwrap_or_throw(&mut env);
+    let expr = l_expr.is_in(lit(s).implode(false), true);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn isBetween<'local>(
+    mut env: JNIEnv<'local>,
+    _: JClass,
+    expr_ptr: *mut Expr,
+    lower: JObject<'local>,
+    upper: JObject<'local>,
+) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+
+    let l_lit = jobject_to_expr(&mut env, &lower);
+    let u_lit = jobject_to_expr(&mut env, &upper);
+
+    let expr = l_expr.is_between(l_lit, u_lit, ClosedInterval::Both);
+    to_ptr(expr)
+}
+
+fn escape_regex(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len() * 2);
+    for c in s.chars() {
+        match c {
+            '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' => {
+                escaped.push('\\');
+                escaped.push(c);
+            },
+            _ => escaped.push(c),
+        }
+    }
+    escaped
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn like(mut env: JNIEnv, _: JClass, expr_ptr: *mut Expr, pattern: JString) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let pat = j_string_to_string(
+        &mut env,
+        &pattern,
+        Some("Failed to parse pattern as string"),
+    );
+
+    let escaped = escape_regex(&pat);
+    let regex_pattern = format!("^{}$", escaped.replace('%', ".*").replace('_', "."));
+    let expr = l_expr.str().contains(lit(regex_pattern), true);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn to_uppercase(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let expr = l_expr.str().to_uppercase();
     to_ptr(expr)
 }
 


### PR DESCRIPTION
This pull request adds new types and features.

### What is new?

- **Simple Types**: Added exact integer types like Int8 and UInt32. This prevents losing information.
- **Java Friendly**: Created a simple `DataTypes` class for Java users. You can now use `DataTypes.Int32` easily.
- **New Features**:
  - `cast`: Convert columns to other types.
  - `isIn`: Check if values match any in a list.
  - `isBetween`: Check if values fall in a range.
  - `like`: Match strings using SQL wildcard patterns.
  - `str.to_uppercase`: Convert strings to uppercase.
- **Safe Code**: Fixed potential memory bugs by keeping the parent Column alive.
- **Tests**: Added full tests for both Scala and Java. All 14 tests pass successfully.