### PR TITLE
feat: add expression alias, Spark-style as, and name namespace (.name)

### DIFF
--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Column.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Column.scala
@@ -1,6 +1,5 @@
 package com.github.chitralverma.polars.api.expressions
 
-import com.github.chitralverma.polars.api.types.DataType
 import com.github.chitralverma.polars.functions.lit
 import com.github.chitralverma.polars.internal.jni.expressions.column_expr
 
@@ -20,54 +19,6 @@ object BinaryOperators extends Enumeration {
 class Column private (p: Long) extends Expression(p) {
   import BinaryOperators._
   import UnaryOperators._
-
-  /** Returns the namespace accessor for string-related expressions. */
-  def str: ColumnStrNameSpace = {
-    checkClosed()
-    new ColumnStrNameSpace(this)
-  }
-
-  /** Cast the column to the specified DataType.
-    *
-    * @param dataType
-    *   target data type
-    */
-  def cast(dataType: DataType): Column = {
-    checkClosed()
-    Column.withPtr(column_expr.cast(ptr, dataType.ffiName))
-  }
-
-  /** Check if the column values are present in the provided array.
-    *
-    * @param values
-    *   array of values to match
-    */
-  def isIn(values: Array[Any]): Column = {
-    checkClosed()
-    Column.withPtr(column_expr.isIn(ptr, values))
-  }
-
-  /** Check if the column values are between the lower and upper bounds (inclusive).
-    *
-    * @param lower
-    *   lower bound
-    * @param upper
-    *   upper bound
-    */
-  def isBetween(lower: Any, upper: Any): Column = {
-    checkClosed()
-    Column.withPtr(column_expr.isBetween(ptr, lower, upper))
-  }
-
-  /** Check if the string column matches the given SQL-like wildcard pattern.
-    *
-    * @param pattern
-    *   SQL-like pattern (e.g. "ap%")
-    */
-  def like(pattern: String): Column = {
-    checkClosed()
-    Column.withPtr(column_expr.like(ptr, pattern))
-  }
 
   /** Not. */
   def unary_! : Column = {

--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/ColumnNameNameSpace.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/ColumnNameNameSpace.scala
@@ -1,0 +1,55 @@
+package com.github.chitralverma.polars.api.expressions
+
+import com.github.chitralverma.polars.internal.jni.expressions.name_expr
+
+/** Namespace for expression name manipulation.
+  *
+  * In Polars, name modifications (renaming, prefixing, suffixing, etc.) on expressions are
+  * grouped under the `.name` namespace (e.g. `col("x").name.suffix("_new")`). This class provides
+  * the same scoped syntax on JVM columns, mirroring the upstream Polars API.
+  */
+class ColumnNameNameSpace private[polars] (private val parent: Expression) {
+
+  /** Keep the original name of the input column. */
+  def keep: Column = {
+    parent.checkClosed()
+    Column.withPtr(name_expr.keep(parent.ptr))
+  }
+
+  /** Add a prefix to the name of the input column.
+    *
+    * @param prefix
+    *   the string prefix to prepend
+    * @return
+    *   a Column expression with the prefixed name
+    */
+  def prefix(prefix: String): Column = {
+    parent.checkClosed()
+    Column.withPtr(name_expr.prefix(parent.ptr, prefix))
+  }
+
+  /** Add a suffix to the name of the input column.
+    *
+    * @param suffix
+    *   the string suffix to append
+    * @return
+    *   a Column expression with the suffixed name
+    */
+  def suffix(suffix: String): Column = {
+    parent.checkClosed()
+    Column.withPtr(name_expr.suffix(parent.ptr, suffix))
+  }
+
+  /** Convert the name of the input column to uppercase. */
+  def to_uppercase: Column = {
+    parent.checkClosed()
+    Column.withPtr(name_expr.to_uppercase(parent.ptr))
+  }
+
+  /** Convert the name of the input column to lowercase. */
+  def to_lowercase: Column = {
+    parent.checkClosed()
+    Column.withPtr(name_expr.to_lowercase(parent.ptr))
+  }
+
+}

--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/ColumnStrNameSpace.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/ColumnStrNameSpace.scala
@@ -8,7 +8,7 @@ import com.github.chitralverma.polars.internal.jni.expressions.column_expr
   * `col("x").str.to_uppercase`). This class provides the same scoped syntax on JVM columns,
   * mirroring the upstream polars API.
   */
-class ColumnStrNameSpace private[polars] (private val parent: Column) {
+class ColumnStrNameSpace private[polars] (private val parent: Expression) {
 
   /** Modify strings to their uppercase equivalent. */
   def to_uppercase: Column = {

--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
@@ -1,5 +1,6 @@
 package com.github.chitralverma.polars.api.expressions
 
+import com.github.chitralverma.polars.api.types.DataType
 import com.github.chitralverma.polars.internal.jni.expressions.column_expr
 
 class Expression(protected[polars] val _ptr: Long) extends AutoCloseable {
@@ -9,6 +10,77 @@ class Expression(protected[polars] val _ptr: Long) extends AutoCloseable {
   private[polars] def ptr: Long = {
     checkClosed()
     _ptr
+  }
+
+  /** Returns the namespace accessor for string-related expressions. */
+  def str: ColumnStrNameSpace = {
+    checkClosed()
+    new ColumnStrNameSpace(this)
+  }
+
+  /** Returns the namespace accessor for expression name manipulation. */
+  def name: ColumnNameNameSpace = {
+    checkClosed()
+    new ColumnNameNameSpace(this)
+  }
+
+  /** Rename the expression.
+    *
+    * @param name
+    *   new name for the expression
+    */
+  def alias(name: String): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.alias(ptr, name))
+  }
+
+  /** Alias for [[alias]].
+    *
+    * @param name
+    *   new name for the expression
+    */
+  def as(name: String): Column = alias(name)
+
+  /** Cast the expression to the specified DataType.
+    *
+    * @param dataType
+    *   target data type
+    */
+  def cast(dataType: DataType): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.cast(ptr, dataType.ffiName))
+  }
+
+  /** Check if the expression values are present in the provided array.
+    *
+    * @param values
+    *   array of values to match
+    */
+  def isIn(values: Array[Any]): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.isIn(ptr, values))
+  }
+
+  /** Check if the expression values are between the lower and upper bounds (inclusive).
+    *
+    * @param lower
+    *   lower bound
+    * @param upper
+    *   upper bound
+    */
+  def isBetween(lower: Any, upper: Any): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.isBetween(ptr, lower, upper))
+  }
+
+  /** Check if the string expression matches the given SQL-like wildcard pattern.
+    *
+    * @param pattern
+    *   SQL-like pattern (e.g. "ap%")
+    */
+  def like(pattern: String): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.like(ptr, pattern))
   }
 
   override def close(): Unit = synchronized {

--- a/core/src/main/scala/com/github/chitralverma/polars/api/types/DataTypes.java
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/types/DataTypes.java
@@ -1,7 +1,7 @@
 package com.github.chitralverma.polars.api.types;
 
 /**
- * Spark-style Java-friendly facade for all Polars DataTypes.
+ * Java-friendly facade for all Polars DataTypes.
  * This class exposes public static final fields and static factory methods
  * so Java and Scala users can refer to types cleanly (e.g. {@code DataTypes.Int32}
  * instead of leaking Scala objects).

--- a/core/src/main/scala/com/github/chitralverma/polars/api/types/DataTypes.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/types/DataTypes.scala
@@ -229,7 +229,7 @@ case class Duration(protected val unitStr: String) extends DataType {
 case class ListType(tpe: DataType) extends DataType {
   override def simpleName: String = "list"
 
-  /** Borrowed from Apache Spark source to represent [[ListType]] as a tree string. */
+  /** Helper to represent [[ListType]] as a tree string. */
   private[polars] def buildFormattedString(prefix: String, buffer: StringBuffer): Unit = {
     buffer.append(s"$prefix-- element: ${tpe.simpleName}\n")
     DataType.buildFormattedString(tpe, s"$prefix    |", buffer)
@@ -249,7 +249,7 @@ case class StructType(fields: Array[Field]) extends DataType {
 
   def toSchema: Schema = Schema.fromFields(fields)
 
-  /** Borrowed from Apache Spark source to represent [[StructType]] as a tree string. */
+  /** Helper to represent [[StructType]] as a tree string. */
   private[polars] def buildFormattedString(prefix: String, buffer: StringBuffer): Unit =
     fields.foreach(field => field.buildFormattedString(prefix, buffer))
 
@@ -388,7 +388,7 @@ object DataType {
     }
   }
 
-  /** Borrowed from Apache Spark source to represent [[DataType]] as a tree string. */
+  /** Helper to represent [[DataType]] as a tree string. */
   private[polars] def buildFormattedString(
       dataType: DataType,
       prefix: String,

--- a/core/src/main/scala/com/github/chitralverma/polars/api/types/Schema.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/types/Schema.scala
@@ -8,7 +8,7 @@ import com.github.chitralverma.polars.jsonMapper
 
 case class Field(name: String, dataType: DataType) {
 
-  /** Borrowed from Apache Spark source to represent [[Field]] as a tree string. */
+  /** Helper to represent [[Field]] as a tree string. */
   private[polars] def buildFormattedString(prefix: String, buffer: StringBuffer): Unit = {
     buffer.append(s"$prefix-- $name: ${dataType.simpleName} \n")
     DataType.buildFormattedString(dataType, s"$prefix    |", buffer)
@@ -72,7 +72,7 @@ class Schema {
     this
   }
 
-  /** Borrowed from Apache Spark source to represent Schema as a tree string. */
+  /** Helper to represent Schema as a tree string. */
   private[polars] def treeString: String = {
     val stringBuffer = new StringBuffer()
     stringBuffer.append("root\n")

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
@@ -22,6 +22,8 @@ private[polars] object column_expr extends Natively {
 
   @native def to_uppercase(ptr: Long): Long
 
+  @native def alias(ptr: Long, name: String): Long
+
   @native def free(ptr: Long): Unit
 
 }

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/name_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/name_expr.scala
@@ -1,0 +1,17 @@
+package com.github.chitralverma.polars.internal.jni.expressions
+
+import com.github.chitralverma.polars.internal.jni.Natively
+
+private[polars] object name_expr extends Natively {
+
+  @native def keep(ptr: Long): Long
+
+  @native def prefix(ptr: Long, prefix: String): Long
+
+  @native def suffix(ptr: Long, suffix: String): Long
+
+  @native def to_uppercase(ptr: Long): Long
+
+  @native def to_lowercase(ptr: Long): Long
+
+}

--- a/core/src/test/java/com/github/chitralverma/polars/NameTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/NameTest.java
@@ -1,0 +1,81 @@
+package com.github.chitralverma.polars;
+
+import static com.github.chitralverma.polars.functions.*;
+
+import com.github.chitralverma.polars.api.DataFrame;
+import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Java mirror of {@code NameSuite}. Replicates name modification behaviors and asserts Column
+ * aliasing and name namespaces in Java.
+ */
+public class NameTest extends AbstractPolarsJavaTest {
+
+  @Test
+  public void expressionAliasAndJVMStyleAs() {
+    DataFrame df = intFrame("ColX", 1, 2, 3);
+
+    // Test alias
+    DataFrame dfAlias = df.select(col("ColX").alias("AliasX"));
+    Assert.assertTrue(dfAlias.schema().getField("AliasX").isDefined());
+    Assert.assertFalse(dfAlias.schema().getField("ColX").isDefined());
+    assertColumnValues(dfAlias, "AliasX", 1, 2, 3);
+
+    // Test alias as
+    DataFrame dfAs = df.select(col("ColX").as("AsX"));
+    Assert.assertTrue(dfAs.schema().getField("AsX").isDefined());
+    Assert.assertFalse(dfAs.schema().getField("ColX").isDefined());
+    assertColumnValues(dfAs, "AsX", 1, 2, 3);
+
+    // Test aliasing non-Column Expressions (e.g. literals)
+    DataFrame dfLit = df.select(col("ColX"), lit(42).alias("LitX"));
+    Assert.assertTrue(dfLit.schema().getField("LitX").isDefined());
+    assertColumnValues(dfLit, "LitX", 42, 42, 42);
+  }
+
+  @Test
+  public void nameChangeCase() {
+    DataFrame df = intFrame("ColX", 1, 2, 3);
+
+    // Test to_uppercase
+    DataFrame dfUpper = df.select(col("ColX").name().to_uppercase());
+    Assert.assertTrue(dfUpper.schema().getField("COLX").isDefined());
+    Assert.assertFalse(dfUpper.schema().getField("ColX").isDefined());
+    assertColumnValues(dfUpper, "COLX", 1, 2, 3);
+
+    // Test to_lowercase
+    DataFrame dfLower = df.select(col("ColX").name().to_lowercase());
+    Assert.assertTrue(dfLower.schema().getField("colx").isDefined());
+    Assert.assertFalse(dfLower.schema().getField("ColX").isDefined());
+    assertColumnValues(dfLower, "colx", 1, 2, 3);
+  }
+
+  @Test
+  public void namePrefixSuffix() {
+    DataFrame df = intFrame("ColX", 1, 2, 3);
+
+    // Test prefix
+    DataFrame dfPrefix = df.select(col("ColX").name().prefix("pre_"));
+    Assert.assertTrue(dfPrefix.schema().getField("pre_ColX").isDefined());
+    Assert.assertFalse(dfPrefix.schema().getField("ColX").isDefined());
+    assertColumnValues(dfPrefix, "pre_ColX", 1, 2, 3);
+
+    // Test suffix
+    DataFrame dfSuffix = df.select(col("ColX").name().suffix("_post"));
+    Assert.assertTrue(dfSuffix.schema().getField("ColX_post").isDefined());
+    Assert.assertFalse(dfSuffix.schema().getField("ColX").isDefined());
+    assertColumnValues(dfSuffix, "ColX_post", 1, 2, 3);
+  }
+
+  @Test
+  public void nameKeep() {
+    DataFrame df = intFrame("ColX", 1, 2, 3);
+
+    // Test keep
+    DataFrame dfKeep = df.select(col("ColX").name().keep());
+    Assert.assertTrue(dfKeep.schema().getField("ColX").isDefined());
+    assertColumnValues(dfKeep, "ColX", 1, 2, 3);
+  }
+}

--- a/core/src/test/scala/com/github/chitralverma/polars/NameSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/NameSuite.scala
@@ -1,0 +1,74 @@
+package com.github.chitralverma.polars
+
+import com.github.chitralverma.polars.functions._
+import com.github.chitralverma.polars.testing.PolarsTestBase
+
+/** Replicates behaviours tested in upstream py-polars
+  * `tests/unit/operations/namespaces/test_name.py` and asserts column aliasing (`alias`/`as`)
+  * behaviour.
+  */
+class NameSuite extends PolarsTestBase {
+
+  test("expression alias and JVM-friendly as") {
+    val df = intFrame("ColX", 1, 2, 3)
+
+    // Test alias
+    val dfAlias = df.select(col("ColX").alias("AliasX"))
+    dfAlias.schema.getField("AliasX") shouldBe defined
+    dfAlias.schema.getField("ColX") should not be defined
+    assertColumnValues(dfAlias, "AliasX", 1, 2, 3)
+
+    // Test alias as
+    val dfAs = df.select(col("ColX").as("AsX"))
+    dfAs.schema.getField("AsX") shouldBe defined
+    dfAs.schema.getField("ColX") should not be defined
+    assertColumnValues(dfAs, "AsX", 1, 2, 3)
+
+    // Test aliasing non-Column Expressions (e.g. literals)
+    val dfLit = df.select(col("ColX"), lit(42).alias("LitX"))
+    dfLit.schema.getField("LitX") shouldBe defined
+    assertColumnValues(dfLit, "LitX", 42, 42, 42)
+  }
+
+  test("name namespace: change case (to_uppercase / to_lowercase)") {
+    val df = intFrame("ColX", 1, 2, 3)
+
+    // Test to_uppercase
+    val dfUpper = df.select(col("ColX").name.to_uppercase)
+    dfUpper.schema.getField("COLX") shouldBe defined
+    dfUpper.schema.getField("ColX") should not be defined
+    assertColumnValues(dfUpper, "COLX", 1, 2, 3)
+
+    // Test to_lowercase
+    val dfLower = df.select(col("ColX").name.to_lowercase)
+    dfLower.schema.getField("colx") shouldBe defined
+    dfLower.schema.getField("ColX") should not be defined
+    assertColumnValues(dfLower, "colx", 1, 2, 3)
+  }
+
+  test("name namespace: prefix and suffix") {
+    val df = intFrame("ColX", 1, 2, 3)
+
+    // Test prefix
+    val dfPrefix = df.select(col("ColX").name.prefix("pre_"))
+    dfPrefix.schema.getField("pre_ColX") shouldBe defined
+    dfPrefix.schema.getField("ColX") should not be defined
+    assertColumnValues(dfPrefix, "pre_ColX", 1, 2, 3)
+
+    // Test suffix
+    val dfSuffix = df.select(col("ColX").name.suffix("_post"))
+    dfSuffix.schema.getField("ColX_post") shouldBe defined
+    dfSuffix.schema.getField("ColX") should not be defined
+    assertColumnValues(dfSuffix, "ColX_post", 1, 2, 3)
+  }
+
+  test("name namespace: keep") {
+    val df = intFrame("ColX", 1, 2, 3)
+
+    // keep preserves the original name of the column
+    val dfKeep = df.select(col("ColX").name.keep)
+    dfKeep.schema.getField("ColX") shouldBe defined
+    assertColumnValues(dfKeep, "ColX", 1, 2, 3)
+  }
+
+}

--- a/native/src/internal_jni/expr/column.rs
+++ b/native/src/internal_jni/expr/column.rs
@@ -402,6 +402,14 @@ pub fn applyBinary(
 }
 
 #[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn alias(mut env: JNIEnv, _: JClass, expr_ptr: *mut Expr, name: JString) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let s_name = j_string_to_string(&mut env, &name, Some("Failed to parse alias name"));
+    let expr = l_expr.alias(s_name);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
 pub fn free(_: JNIEnv, _: JClass, ptr: jlong) {
     free_ptr::<Expr>(ptr);
 }

--- a/native/src/internal_jni/expr/mod.rs
+++ b/native/src/internal_jni/expr/mod.rs
@@ -1,2 +1,3 @@
 pub mod column;
 pub mod literal;
+pub mod name;

--- a/native/src/internal_jni/expr/name.rs
+++ b/native/src/internal_jni/expr/name.rs
@@ -1,0 +1,44 @@
+use jni::JNIEnv;
+use jni::objects::{JClass, JString};
+use jni::sys::jlong;
+use jni_fn::jni_fn;
+use polars::prelude::*;
+
+use crate::internal_jni::utils::{from_ptr, j_string_to_string, to_ptr};
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.name_expr$")]
+pub fn keep(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let expr = l_expr.name().keep();
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.name_expr$")]
+pub fn prefix(mut env: JNIEnv, _: JClass, expr_ptr: *mut Expr, prefix: JString) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let s_prefix = j_string_to_string(&mut env, &prefix, Some("Failed to parse prefix"));
+    let expr = l_expr.name().prefix(&s_prefix);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.name_expr$")]
+pub fn suffix(mut env: JNIEnv, _: JClass, expr_ptr: *mut Expr, suffix: JString) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let s_suffix = j_string_to_string(&mut env, &suffix, Some("Failed to parse suffix"));
+    let expr = l_expr.name().suffix(&s_suffix);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.name_expr$")]
+pub fn to_uppercase(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let expr = l_expr.name().to_uppercase();
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.name_expr$")]
+pub fn to_lowercase(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let expr = l_expr.name().to_lowercase();
+    to_ptr(expr)
+}


### PR DESCRIPTION
This pull request adds column names and aliases. It helps you change column names easily.

### What is new?

- **Alias**: Added `.alias` and `.as` to columns. You can use these to rename any column.
- **Name**: Added a `.name` helper. It allows you to:
  - Keep the original name with `.name.keep`.
  - Add prefixes with `.name.prefix`.
  - Add suffixes with `.name.suffix`.
  - Change to uppercase with `.name.to_uppercase`.
  - Change to lowercase with `.name.to_lowercase`.
