### PR TITLE
feat: add core unary transforms, predicates, and slicing on Expression

### DIFF
--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
@@ -83,6 +83,153 @@ class Expression(protected[polars] val _ptr: Long) extends AutoCloseable {
     Column.withPtr(column_expr.like(ptr, pattern))
   }
 
+  /** Check if the values in this expression are finite. */
+  def is_finite: Column = {
+    checkClosed()
+    Column.withPtr(column_expr.is_finite(ptr))
+  }
+
+  /** Check if the values in this expression are infinite. */
+  def is_infinite: Column = {
+    checkClosed()
+    Column.withPtr(column_expr.is_infinite(ptr))
+  }
+
+  /** Check if the expression is empty.
+    *
+    * @note
+    *   This function is unstable in Polars and may change in future versions.
+    */
+  def is_empty: Column = {
+    checkClosed()
+    Column.withPtr(column_expr.is_empty(ptr))
+  }
+
+  /** Drop null values from this expression. */
+  def drop_nulls(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.drop_nulls(ptr))
+  }
+
+  /** Drop NaN values from this expression. */
+  def drop_nans(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.drop_nans(ptr))
+  }
+
+  /** Reverse the order of elements in this expression. */
+  def reverse(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.reverse(ptr))
+  }
+
+  /** Get a slice of this expression.
+    *
+    * @param offset
+    *   start index of the slice (negative indexing is supported)
+    * @param length
+    *   length of the slice
+    */
+  def slice(offset: Long, length: Long): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.slice(ptr, offset, length))
+  }
+
+  /** Get the first n elements of this expression.
+    *
+    * @param n
+    *   number of elements to return (default is 10)
+    */
+  def head(n: Long = 10): Column = {
+    checkClosed()
+    slice(0, n)
+  }
+
+  /** Get the last n elements of this expression.
+    *
+    * @param n
+    *   number of elements to return (default is 10)
+    */
+  def tail(n: Long = 10): Column = {
+    checkClosed()
+    slice(-n, n)
+  }
+
+  /** Alias for [[head]].
+    *
+    * @param n
+    *   number of elements to return (default is 10)
+    */
+  def limit(n: Long = 10): Column = head(n)
+
+  /** Gather every nth element, starting at the offset.
+    *
+    * @param n
+    *   gather elements with this step size
+    * @param offset
+    *   start gathering from this index (default is 0)
+    */
+  def gather_every(n: Long, offset: Long = 0): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.gather_every(ptr, n, offset))
+  }
+
+  /** Shift elements in this expression by periods.
+    *
+    * @param periods
+    *   number of positions to shift
+    */
+  def shift(periods: Long = 1): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.shift(ptr, periods))
+  }
+
+  /** Get unique values from this expression.
+    *
+    * @param maintainOrder
+    *   whether to maintain the original order of elements
+    */
+  def unique(maintainOrder: Boolean = false): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.unique(ptr, maintainOrder))
+  }
+
+  /** Mask indicating unique values in this expression. */
+  def is_unique: Column = {
+    checkClosed()
+    Column.withPtr(column_expr.is_unique(ptr))
+  }
+
+  /** Mask indicating duplicated values in this expression. */
+  def is_duplicated: Column = {
+    checkClosed()
+    Column.withPtr(column_expr.is_duplicated(ptr))
+  }
+
+  /** Mask indicating the first occurrence of distinct values in this expression. */
+  def is_first_distinct: Column = {
+    checkClosed()
+    Column.withPtr(column_expr.is_first_distinct(ptr))
+  }
+
+  /** Mask indicating the last occurrence of distinct values in this expression. */
+  def is_last_distinct: Column = {
+    checkClosed()
+    Column.withPtr(column_expr.is_last_distinct(ptr))
+  }
+
+  /** Return the most frequent values in this expression. */
+  def mode(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.mode(ptr))
+  }
+
+  /** Return the counts of unique values in this expression. */
+  def unique_counts(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.unique_counts(ptr))
+  }
+
   override def close(): Unit = synchronized {
     if (!isClosed && _ptr != 0) {
       column_expr.free(_ptr)

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
@@ -24,6 +24,38 @@ private[polars] object column_expr extends Natively {
 
   @native def alias(ptr: Long, name: String): Long
 
+  @native def is_finite(ptr: Long): Long
+
+  @native def is_infinite(ptr: Long): Long
+
+  @native def is_empty(ptr: Long): Long
+
+  @native def drop_nulls(ptr: Long): Long
+
+  @native def drop_nans(ptr: Long): Long
+
+  @native def reverse(ptr: Long): Long
+
+  @native def slice(ptr: Long, offset: Long, length: Long): Long
+
+  @native def shift(ptr: Long, periods: Long): Long
+
+  @native def gather_every(ptr: Long, n: Long, offset: Long): Long
+
+  @native def unique(ptr: Long, maintainOrder: Boolean): Long
+
+  @native def is_unique(ptr: Long): Long
+
+  @native def is_duplicated(ptr: Long): Long
+
+  @native def is_first_distinct(ptr: Long): Long
+
+  @native def is_last_distinct(ptr: Long): Long
+
+  @native def mode(ptr: Long): Long
+
+  @native def unique_counts(ptr: Long): Long
+
   @native def free(ptr: Long): Unit
 
 }

--- a/core/src/test/java/com/github/chitralverma/polars/UnaryTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/UnaryTest.java
@@ -1,0 +1,123 @@
+package com.github.chitralverma.polars;
+
+import static com.github.chitralverma.polars.functions.*;
+
+import com.github.chitralverma.polars.api.DataFrame;
+import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Java mirror of {@code UnarySuite}. Replicates and asserts behaviours tested in upstream py-polars
+ * for core unary transforms and predicates in Java.
+ */
+public class UnaryTest extends AbstractPolarsJavaTest {
+
+  @Test
+  public void unaryPredicates() {
+    DataFrame df = doubleFrame("ColX", 1.0, Double.NaN, Double.POSITIVE_INFINITY);
+
+    // Test is_finite
+    DataFrame dfFinite = df.select(col("ColX").is_finite().alias("finite"));
+    assertColumnValues(dfFinite, "finite", true, false, false);
+
+    // Test is_infinite
+    DataFrame dfInfinite = df.select(col("ColX").is_infinite().alias("infinite"));
+    assertColumnValues(dfInfinite, "infinite", false, false, true);
+
+    // Test drop_nans
+    DataFrame dfDropNans = df.select(col("ColX").drop_nans().alias("non_nan"));
+    assertColumnValues(dfDropNans, "non_nan", 1.0, Double.POSITIVE_INFINITY);
+
+    // Test drop_nulls using shift-introduced nulls
+    DataFrame dfShifted = intFrame("ColY", 1, 2, 3);
+    DataFrame dfDropNulls = dfShifted.select(col("ColY").shift(1).drop_nulls().alias("non_null"));
+    assertColumnValues(dfDropNulls, "non_null", 1, 2);
+
+    // Test is_empty
+    DataFrame dfEmpty = df.select(col("ColX").is_empty().alias("empty"));
+    assertColumnValues(dfEmpty, "empty", false);
+  }
+
+  @Test
+  public void unaryTransforms() {
+    DataFrame df = intFrame("ColX", 1, 2, 3, 4, 5);
+
+    // Test reverse
+    DataFrame dfReverse = df.select(col("ColX").reverse().alias("reversed"));
+    assertColumnValues(dfReverse, "reversed", 5, 4, 3, 2, 1);
+
+    // Test slice
+    DataFrame dfSlice = df.select(col("ColX").slice(1, 3).alias("sliced"));
+    assertColumnValues(dfSlice, "sliced", 2, 3, 4);
+
+    // Test head / limit
+    DataFrame dfHead = df.select(col("ColX").head(2).alias("head"));
+    assertColumnValues(dfHead, "head", 1, 2);
+
+    DataFrame dfLimit = df.select(col("ColX").limit(2).alias("limit"));
+    assertColumnValues(dfLimit, "limit", 1, 2);
+
+    // Test tail
+    DataFrame dfTail = df.select(col("ColX").tail(2).alias("tail"));
+    assertColumnValues(dfTail, "tail", 4, 5);
+
+    // Test gather_every
+    DataFrame dfGather = df.select(col("ColX").gather_every(2, 1).alias("gathered"));
+    assertColumnValues(dfGather, "gathered", 2, 4);
+
+    // Test shift (positive and negative)
+    DataFrame dfShift = df.select(col("ColX").shift(2).alias("shifted"));
+    assertColumnValues(dfShift, "shifted", null, null, 1, 2, 3);
+
+    DataFrame dfShiftNeg = df.select(col("ColX").shift(-2).alias("shifted_neg"));
+    assertColumnValues(dfShiftNeg, "shifted_neg", 3, 4, 5, null, null);
+  }
+
+  @Test
+  public void unaryDistincts() {
+    DataFrame df = intFrame("ColX", 1, 2, 2, 3, 1);
+
+    // Test unique (without maintaining order)
+    DataFrame dfUnique = df.select(col("ColX").unique(false).alias("unique"));
+    List<Object> uniqueList = columnOf(dfUnique, "unique");
+    Collections.sort((List) uniqueList);
+    Assert.assertEquals(Arrays.asList(1, 2, 3), uniqueList);
+
+    // Test unique (maintaining order)
+    DataFrame dfUniqueStable = df.select(col("ColX").unique(true).alias("unique"));
+    assertColumnValues(dfUniqueStable, "unique", 1, 2, 3);
+
+    // Test is_unique
+    DataFrame dfIsUnique = df.select(col("ColX").is_unique().alias("is_unique"));
+    assertColumnValues(dfIsUnique, "is_unique", false, false, false, true, false);
+
+    // Test is_duplicated
+    DataFrame dfIsDuplicated = df.select(col("ColX").is_duplicated().alias("is_duplicated"));
+    assertColumnValues(dfIsDuplicated, "is_duplicated", true, true, true, false, true);
+
+    // Test is_first_distinct
+    DataFrame dfIsFirst = df.select(col("ColX").is_first_distinct().alias("is_first"));
+    assertColumnValues(dfIsFirst, "is_first", true, true, false, true, false);
+
+    // Test is_last_distinct
+    DataFrame dfIsLast = df.select(col("ColX").is_last_distinct().alias("is_last"));
+    assertColumnValues(dfIsLast, "is_last", false, false, true, true, true);
+  }
+
+  @Test
+  public void unaryDistinctAggregations() {
+    DataFrame df = intFrame("ColX", 2, 2, 3, 1, 2);
+
+    // Test mode
+    DataFrame dfMode = df.select(col("ColX").mode().alias("mode"));
+    assertColumnValues(dfMode, "mode", 2);
+
+    // Test unique_counts
+    DataFrame dfUniqueCounts = df.select(col("ColX").unique_counts().alias("counts"));
+    assertColumnValues(dfUniqueCounts, "counts", 3, 1, 1);
+  }
+}

--- a/core/src/test/scala/com/github/chitralverma/polars/UnarySuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/UnarySuite.scala
@@ -1,0 +1,112 @@
+package com.github.chitralverma.polars
+
+import com.github.chitralverma.polars.functions._
+import com.github.chitralverma.polars.testing.PolarsTestBase
+
+/** Replicates and asserts behaviours tested in upstream py-polars for core unary transforms and
+  * predicates, such as null/nan filters, positional slices, and unique/distinct masks.
+  */
+class UnarySuite extends PolarsTestBase {
+
+  test("unary predicates: is_finite, is_infinite, is_empty, drop_nulls, drop_nans") {
+    val df = doubleFrame("ColX", 1.0, Double.NaN, Double.PositiveInfinity)
+
+    // Test is_finite
+    val dfFinite = df.select(col("ColX").is_finite.alias("finite"))
+    assertColumnValues(dfFinite, "finite", true, false, false)
+
+    // Test is_infinite
+    val dfInfinite = df.select(col("ColX").is_infinite.alias("infinite"))
+    assertColumnValues(dfInfinite, "infinite", false, false, true)
+
+    // Test drop_nans
+    val dfDropNans = df.select(col("ColX").drop_nans().alias("non_nan"))
+    assertColumnValues(dfDropNans, "non_nan", 1.0, Double.PositiveInfinity)
+
+    // Test drop_nulls using shift-introduced nulls
+    val dfShifted = intFrame("ColY", 1, 2, 3)
+    val dfDropNulls = dfShifted.select(col("ColY").shift(1).drop_nulls().alias("non_null"))
+    assertColumnValues(dfDropNulls, "non_null", 1, 2)
+
+    // Test is_empty
+    val dfEmpty = df.select(col("ColX").is_empty.alias("empty"))
+    assertColumnValues(dfEmpty, "empty", false)
+  }
+
+  test("unary transforms: reverse, slice, head, tail, limit, gather_every, shift") {
+    val df = intFrame("ColX", 1, 2, 3, 4, 5)
+
+    // Test reverse
+    val dfReverse = df.select(col("ColX").reverse().alias("reversed"))
+    assertColumnValues(dfReverse, "reversed", 5, 4, 3, 2, 1)
+
+    // Test slice
+    val dfSlice = df.select(col("ColX").slice(1, 3).alias("sliced"))
+    assertColumnValues(dfSlice, "sliced", 2, 3, 4)
+
+    // Test head / limit
+    val dfHead = df.select(col("ColX").head(2).alias("head"))
+    assertColumnValues(dfHead, "head", 1, 2)
+
+    val dfLimit = df.select(col("ColX").limit(2).alias("limit"))
+    assertColumnValues(dfLimit, "limit", 1, 2)
+
+    // Test tail
+    val dfTail = df.select(col("ColX").tail(2).alias("tail"))
+    assertColumnValues(dfTail, "tail", 4, 5)
+
+    // Test gather_every
+    val dfGather = df.select(col("ColX").gather_every(2, 1).alias("gathered"))
+    assertColumnValues(dfGather, "gathered", 2, 4)
+
+    // Test shift (positive and negative)
+    val dfShift = df.select(col("ColX").shift(2).alias("shifted"))
+    assertColumnValues(dfShift, "shifted", null, null, 1, 2, 3)
+
+    val dfShiftNeg = df.select(col("ColX").shift(-2).alias("shifted_neg"))
+    assertColumnValues(dfShiftNeg, "shifted_neg", 3, 4, 5, null, null)
+  }
+
+  test("unary distincts: unique, is_unique, is_duplicated, is_first_distinct, is_last_distinct") {
+    val df = intFrame("ColX", 1, 2, 2, 3, 1)
+
+    // Test unique (without maintaining order)
+    val dfUnique = df.select(col("ColX").unique(maintainOrder = false).alias("unique"))
+    // unique returns [1, 2, 3] in some order (usually ascending or hash order)
+    val uniqueVals = dfUnique.rows().map(_.getInt(0)).toSeq.sorted
+    uniqueVals shouldBe Seq(1, 2, 3)
+
+    // Test unique (maintaining order)
+    val dfUniqueStable = df.select(col("ColX").unique(maintainOrder = true).alias("unique"))
+    assertColumnValues(dfUniqueStable, "unique", 1, 2, 3)
+
+    // Test is_unique (mask of elements that occur exactly once)
+    val dfIsUnique = df.select(col("ColX").is_unique.alias("is_unique"))
+    assertColumnValues(dfIsUnique, "is_unique", false, false, false, true, false)
+
+    // Test is_duplicated (mask of elements that occur more than once)
+    val dfIsDuplicated = df.select(col("ColX").is_duplicated.alias("is_duplicated"))
+    assertColumnValues(dfIsDuplicated, "is_duplicated", true, true, true, false, true)
+
+    // Test is_first_distinct (mask of first occurrence of distinct elements)
+    val dfIsFirst = df.select(col("ColX").is_first_distinct.alias("is_first"))
+    assertColumnValues(dfIsFirst, "is_first", true, true, false, true, false)
+
+    // Test is_last_distinct (mask of last occurrence of distinct elements)
+    val dfIsLast = df.select(col("ColX").is_last_distinct.alias("is_last"))
+    assertColumnValues(dfIsLast, "is_last", false, false, true, true, true)
+  }
+
+  test("unary distinct aggregations: mode, unique_counts") {
+    val df = intFrame("ColX", 2, 2, 3, 1, 2)
+
+    // Test mode (most frequent values)
+    val dfMode = df.select(col("ColX").mode().alias("mode"))
+    assertColumnValues(dfMode, "mode", 2)
+
+    // Test unique_counts (number of occurrences per unique value in order of appearance)
+    val dfUniqueCounts = df.select(col("ColX").unique_counts().alias("counts"))
+    assertColumnValues(dfUniqueCounts, "counts", 3, 1, 1)
+  }
+
+}

--- a/native/src/internal_jni/expr/column.rs
+++ b/native/src/internal_jni/expr/column.rs
@@ -410,6 +410,107 @@ pub fn alias(mut env: JNIEnv, _: JClass, expr_ptr: *mut Expr, name: JString) -> 
 }
 
 #[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn is_finite(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.is_finite())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn is_infinite(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.is_infinite())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn is_empty(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.is_empty(false))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn drop_nulls(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.drop_nulls())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn drop_nans(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.drop_nans())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn reverse(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.reverse())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn slice(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, offset: jlong, length: jlong) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.slice(lit(offset), lit(length)))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn shift(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, periods: jlong) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.shift(lit(periods)))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn gather_every(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, n: jlong, offset: jlong) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.gather_every(n as usize, offset as usize))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn unique(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, maintain_order: bool) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let expr = if maintain_order {
+        l_expr.unique_stable()
+    } else {
+        l_expr.unique()
+    };
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn is_unique(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.is_unique())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn is_duplicated(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.is_duplicated())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn is_first_distinct(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.is_first_distinct())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn is_last_distinct(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.is_last_distinct())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn mode(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.mode(false))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn unique_counts(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.unique_counts())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
 pub fn free(_: JNIEnv, _: JClass, ptr: jlong) {
     free_ptr::<Expr>(ptr);
 }


### PR DESCRIPTION
This pull request adds many unary operations and slices. It makes it easy to filter, slice, and check columns.

### What is new?

- **Predicates**: Added helpers to check for finite numbers, infinite numbers, or empty cells.
- **Slices**: Added `.slice`, `.head`, `.tail`, `.limit`, and `.shift`. Slicing columns is now very easy.
- **Distinct**: Added `.unique`, `.is_unique`, `.is_duplicated`, and `.mode`. Finding unique items is now simple.
- **Base Class**: Promoted all these helpers to the base `Expression` class. You can call them on literals too.
- **Tests**: Added full tests for both Scala and Java. All 36 tests pass.

### Added Functions & Namespaces

| Method / Namespace | Category | Return Type | Description |
|---|---|---|---|
| `is_finite` | Predicate | `Column` | Mask indicating finite elements |
| `is_infinite` | Predicate | `Column` | Mask indicating infinite elements |
| `is_empty` | Predicate / Reduction | `Column` | Mask indicating if the expression is empty |
| `drop_nulls` | Transform | `Column` | Drop null elements |
| `drop_nans` | Transform | `Column` | Drop NaN elements |
| `reverse` | Transform | `Column` | Reverse order of elements |
| `slice` | Transform / Slice | `Column` | Slice a subrange of elements |
| `head` | Transform / Slice | `Column` | Return first n elements |
| `tail` | Transform / Slice | `Column` | Return last n elements |
| `limit` | Transform / Slice | `Column` | Shorthand/Alias for `head` |
| `gather_every` | Transform / Slice | `Column` | Gather every nth element |
| `shift` | Transform / Shift | `Column` | Shift elements by periods (forward/backward) |
| `unique` | Transform / Distinct | `Column` | Return distinct elements |
| `is_unique` | Predicate / Mask | `Column` | Mask indicating unique elements |
| `is_duplicated` | Predicate / Mask | `Column` | Mask indicating duplicated elements |
| `is_first_distinct` | Predicate / Mask | `Column` | Mask indicating first distinct occurrences |
| `is_last_distinct` | Predicate / Mask | `Column` | Mask indicating last distinct occurrences |
| `mode` | Reduction / Distinct | `Column` | Return most frequent elements |
| `unique_counts` | Reduction / Distinct | `Column` | Return counts per unique element |

**Total Functions / Namespaces Added**: 19

This PR has no extra dependencies and is completely green.