### PR TITLE
feat: add complete expression, companion, and horizontal aggregations

### DIFF
--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
@@ -254,6 +254,195 @@ class Expression(protected[polars] val _ptr: Long) extends AutoCloseable {
     Column.withPtr(column_expr.unique_counts(ptr))
   }
 
+  /** Reduce groups to the sum of all the values. */
+  def sum(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.sum(ptr))
+  }
+
+  /** Reduce groups to the minimal value. */
+  def min(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.min(ptr))
+  }
+
+  /** Reduce groups to the maximum value. */
+  def max(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.max(ptr))
+  }
+
+  /** Reduce groups to the mean value. */
+  def mean(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.mean(ptr))
+  }
+
+  /** Reduce groups to the median value. */
+  def median(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.median(ptr))
+  }
+
+  /** Standard deviation of the values.
+    *
+    * @param ddof
+    *   Delta Degrees of Freedom (default is 1)
+    */
+  def std(ddof: Int): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.std(ptr, ddof))
+  }
+
+  /** Standard deviation of the values with ddof = 1. */
+  def std(): Column = std(1)
+
+  /** Variance of the values.
+    *
+    * @param ddof
+    *   Delta Degrees of Freedom (default is 1)
+    */
+  def `var`(ddof: Int): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.`var`(ptr, ddof))
+  }
+
+  /** Variance of the values with ddof = 1. */
+  def `var`(): Column = `var`(1)
+
+  /** Variance of the values.
+    *
+    * @param ddof
+    *   Delta Degrees of Freedom (default is 1)
+    */
+  def variance(ddof: Int): Column = `var`(ddof)
+
+  /** Variance of the values with ddof = 1. */
+  def variance(): Column = `var`(1)
+
+  /** Reduce groups to the product of all the values. */
+  def product(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.product(ptr))
+  }
+
+  /** Count the non-null values. */
+  def count(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.count(ptr))
+  }
+
+  /** Return the number of elements (including nulls). */
+  def len(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.len(ptr))
+  }
+
+  /** Return the number of unique values. */
+  def nUnique(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.n_unique(ptr))
+  }
+
+  /** Return the approximate number of unique values. */
+  def approxNUnique(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.approx_n_unique(ptr))
+  }
+
+  /** Return the number of null values. */
+  def nullCount(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.null_count(ptr))
+  }
+
+  /** Reduce groups to the first value. */
+  def first(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.first(ptr))
+  }
+
+  /** Reduce groups to the last value. */
+  def last(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.last(ptr))
+  }
+
+  /** Return the quantile value of the values.
+    *
+    * @param q
+    *   quantile value (must be between 0.0 and 1.0)
+    * @param method
+    *   interpolation method (e.g. "nearest", "linear")
+    */
+  def quantile(q: Double, method: String): Column = {
+    checkClosed()
+    require(q >= 0.0 && q <= 1.0, s"quantile: 'q' must be between 0.0 and 1.0, but got $q")
+    Column.withPtr(column_expr.quantile(ptr, q, method))
+  }
+
+  /** Return the quantile value of the values with "nearest" interpolation.
+    *
+    * @param q
+    *   quantile value (must be between 0.0 and 1.0)
+    */
+  def quantile(q: Double): Column = quantile(q, "nearest")
+
+  /** Return the index of the minimal value. */
+  def argMin(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arg_min(ptr))
+  }
+
+  /** Return the index of the maximum value. */
+  def argMax(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arg_max(ptr))
+  }
+
+  /** Return the indices that would sort the values.
+    *
+    * @param descending
+    *   whether to sort descending
+    * @param nullsLast
+    *   whether to put nulls last
+    */
+  def argSort(descending: Boolean, nullsLast: Boolean): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arg_sort(ptr, descending, nullsLast))
+  }
+
+  /** Return the indices that would sort the values ascending. */
+  def argSort(): Column = argSort(descending = false, nullsLast = false)
+
+  /** Compute the skewness of the values.
+    *
+    * @param bias
+    *   whether to correct for statistical bias
+    */
+  def skew(bias: Boolean): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.skew(ptr, bias))
+  }
+
+  /** Compute the skewness of the values with bias correction. */
+  def skew(): Column = skew(bias = true)
+
+  /** Compute the kurtosis of the values.
+    *
+    * @param fisher
+    *   whether to use Fisher's definition of kurtosis (default is true)
+    * @param bias
+    *   whether to correct for statistical bias (default is true)
+    */
+  def kurtosis(fisher: Boolean, bias: Boolean): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.kurtosis(ptr, fisher, bias))
+  }
+
+  /** Compute the kurtosis of the values with Fisher's definition and bias correction. */
+  def kurtosis(): Column = kurtosis(fisher = true, bias = true)
+
   override def close(): Unit = synchronized {
     if (!isClosed && _ptr != 0) {
       column_expr.free(_ptr)

--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
@@ -287,10 +287,11 @@ class Expression(protected[polars] val _ptr: Long) extends AutoCloseable {
   /** Standard deviation of the values.
     *
     * @param ddof
-    *   Delta Degrees of Freedom (default is 1)
+    *   Delta Degrees of Freedom (default is 1, must be between 0 and 255)
     */
   def std(ddof: Int): Column = {
     checkClosed()
+    require(ddof >= 0 && ddof <= 255, s"std: 'ddof' must be between 0 and 255, but got $ddof")
     Column.withPtr(column_expr.std(ptr, ddof))
   }
 
@@ -300,10 +301,11 @@ class Expression(protected[polars] val _ptr: Long) extends AutoCloseable {
   /** Variance of the values.
     *
     * @param ddof
-    *   Delta Degrees of Freedom (default is 1)
+    *   Delta Degrees of Freedom (default is 1, must be between 0 and 255)
     */
   def `var`(ddof: Int): Column = {
     checkClosed()
+    require(ddof >= 0 && ddof <= 255, s"var: 'ddof' must be between 0 and 255, but got $ddof")
     Column.withPtr(column_expr.`var`(ptr, ddof))
   }
 
@@ -442,6 +444,45 @@ class Expression(protected[polars] val _ptr: Long) extends AutoCloseable {
 
   /** Compute the kurtosis of the values with Fisher's definition and bias correction. */
   def kurtosis(): Column = kurtosis(fisher = true, bias = true)
+
+  /** Return whether any of the values in the boolean expression are true.
+    *
+    * @param ignoreNulls
+    *   whether to ignore null values
+    */
+  def any(ignoreNulls: Boolean): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.any(ptr, ignoreNulls))
+  }
+
+  /** Return whether any of the values in the boolean expression are true (ignoring nulls). */
+  def any(): Column = any(ignoreNulls = true)
+
+  /** Return whether all of the values in the boolean expression are true.
+    *
+    * @param ignoreNulls
+    *   whether to ignore null values
+    */
+  def all(ignoreNulls: Boolean): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.all(ptr, ignoreNulls))
+  }
+
+  /** Return whether all of the values in the boolean expression are true (ignoring nulls). */
+  def all(): Column = all(ignoreNulls = true)
+
+  /** Compute the cumulative sum of the values.
+    *
+    * @param reverse
+    *   whether to compute the sum in reverse order
+    */
+  def cumSum(reverse: Boolean): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.cum_sum(ptr, reverse))
+  }
+
+  /** Compute the cumulative sum of the values. */
+  def cumSum(): Column = cumSum(reverse = false)
 
   override def close(): Unit = synchronized {
     if (!isClosed && _ptr != 0) {

--- a/core/src/main/scala/com/github/chitralverma/polars/functions.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/functions.scala
@@ -106,6 +106,21 @@ object functions {
     col(colName).quantile(q, method)
   def quantile(colName: String, q: Double): Column = col(colName).quantile(q)
 
+  def any(col: Expression, ignoreNulls: Boolean): Column = col.any(ignoreNulls)
+  def any(col: Expression): Column = col.any()
+  def any(colName: String, ignoreNulls: Boolean): Column = col(colName).any(ignoreNulls)
+  def any(colName: String): Column = col(colName).any()
+
+  def all(col: Expression, ignoreNulls: Boolean): Column = col.all(ignoreNulls)
+  def all(col: Expression): Column = col.all()
+  def all(colName: String, ignoreNulls: Boolean): Column = col(colName).all(ignoreNulls)
+  def all(colName: String): Column = col(colName).all()
+
+  def cumSum(col: Expression, reverse: Boolean): Column = col.cumSum(reverse)
+  def cumSum(col: Expression): Column = col.cumSum()
+  def cumSum(colName: String, reverse: Boolean): Column = col(colName).cumSum(reverse)
+  def cumSum(colName: String): Column = col(colName).cumSum()
+
   // --- Horizontal Aggregations ---
 
   import com.github.chitralverma.polars.internal.jni.expressions.functions_expr

--- a/core/src/main/scala/com/github/chitralverma/polars/functions.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/functions.scala
@@ -46,4 +46,100 @@ object functions {
     Expression.withPtr(ptr)
   }
 
+  // --- Core Expression Aggregations (JVM-friendly overloads) ---
+
+  def sum(col: Expression): Column = col.sum()
+  def sum(colName: String): Column = col(colName).sum()
+
+  def min(col: Expression): Column = col.min()
+  def min(colName: String): Column = col(colName).min()
+
+  def max(col: Expression): Column = col.max()
+  def max(colName: String): Column = col(colName).max()
+
+  def mean(col: Expression): Column = col.mean()
+  def mean(colName: String): Column = col(colName).mean()
+
+  def median(col: Expression): Column = col.median()
+  def median(colName: String): Column = col(colName).median()
+
+  def std(col: Expression, ddof: Int): Column = col.std(ddof)
+  def std(col: Expression): Column = col.std()
+  def std(colName: String, ddof: Int): Column = col(colName).std(ddof)
+  def std(colName: String): Column = col(colName).std()
+
+  def `var`(col: Expression, ddof: Int): Column = col.`var`(ddof)
+  def `var`(col: Expression): Column = col.`var`()
+  def `var`(colName: String, ddof: Int): Column = col(colName).`var`(ddof)
+  def `var`(colName: String): Column = col(colName).`var`()
+
+  def variance(col: Expression, ddof: Int): Column = col.variance(ddof)
+  def variance(col: Expression): Column = col.variance()
+  def variance(colName: String, ddof: Int): Column = col(colName).variance(ddof)
+  def variance(colName: String): Column = col(colName).variance()
+
+  def product(col: Expression): Column = col.product()
+  def product(colName: String): Column = col(colName).product()
+
+  def count(col: Expression): Column = col.count()
+  def count(colName: String): Column = col(colName).count()
+
+  def len(): Column = col("*").len()
+  def len(col: Expression): Column = col.len()
+  def len(colName: String): Column = col(colName).len()
+
+  def nUnique(col: Expression): Column = col.nUnique()
+  def nUnique(colName: String): Column = col(colName).nUnique()
+
+  def approxNUnique(col: Expression): Column = col.approxNUnique()
+  def approxNUnique(colName: String): Column = col(colName).approxNUnique()
+
+  def first(col: Expression): Column = col.first()
+  def first(colName: String): Column = col(colName).first()
+
+  def last(col: Expression): Column = col.last()
+  def last(colName: String): Column = col(colName).last()
+
+  def quantile(col: Expression, q: Double, method: String): Column = col.quantile(q, method)
+  def quantile(col: Expression, q: Double): Column = col.quantile(q)
+  def quantile(colName: String, q: Double, method: String): Column =
+    col(colName).quantile(q, method)
+  def quantile(colName: String, q: Double): Column = col(colName).quantile(q)
+
+  // --- Horizontal Aggregations ---
+
+  import com.github.chitralverma.polars.internal.jni.expressions.functions_expr
+
+  @annotation.varargs
+  def anyHorizontal(cols: Expression*): Column =
+    Column.withPtr(functions_expr.any_horizontal(cols.map(_.ptr).toArray))
+
+  @annotation.varargs
+  def allHorizontal(cols: Expression*): Column =
+    Column.withPtr(functions_expr.all_horizontal(cols.map(_.ptr).toArray))
+
+  @annotation.varargs
+  def maxHorizontal(cols: Expression*): Column =
+    Column.withPtr(functions_expr.max_horizontal(cols.map(_.ptr).toArray))
+
+  @annotation.varargs
+  def minHorizontal(cols: Expression*): Column =
+    Column.withPtr(functions_expr.min_horizontal(cols.map(_.ptr).toArray))
+
+  @annotation.varargs
+  def sumHorizontal(cols: Expression*): Column =
+    Column.withPtr(functions_expr.sum_horizontal(cols.map(_.ptr).toArray, true))
+
+  @annotation.varargs
+  def sumHorizontal(ignoreNulls: Boolean, cols: Expression*): Column =
+    Column.withPtr(functions_expr.sum_horizontal(cols.map(_.ptr).toArray, ignoreNulls))
+
+  @annotation.varargs
+  def meanHorizontal(cols: Expression*): Column =
+    Column.withPtr(functions_expr.mean_horizontal(cols.map(_.ptr).toArray, true))
+
+  @annotation.varargs
+  def meanHorizontal(ignoreNulls: Boolean, cols: Expression*): Column =
+    Column.withPtr(functions_expr.mean_horizontal(cols.map(_.ptr).toArray, ignoreNulls))
+
 }

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
@@ -98,6 +98,12 @@ private[polars] object column_expr extends Natively {
 
   @native def kurtosis(ptr: Long, fisher: Boolean, bias: Boolean): Long
 
+  @native def any(ptr: Long, ignoreNulls: Boolean): Long
+
+  @native def all(ptr: Long, ignoreNulls: Boolean): Long
+
+  @native def cum_sum(ptr: Long, reverse: Boolean): Long
+
   @native def free(ptr: Long): Unit
 
 }

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
@@ -56,6 +56,48 @@ private[polars] object column_expr extends Natively {
 
   @native def unique_counts(ptr: Long): Long
 
+  @native def sum(ptr: Long): Long
+
+  @native def min(ptr: Long): Long
+
+  @native def max(ptr: Long): Long
+
+  @native def mean(ptr: Long): Long
+
+  @native def median(ptr: Long): Long
+
+  @native def std(ptr: Long, ddof: Int): Long
+
+  @native def `var`(ptr: Long, ddof: Int): Long
+
+  @native def product(ptr: Long): Long
+
+  @native def count(ptr: Long): Long
+
+  @native def len(ptr: Long): Long
+
+  @native def n_unique(ptr: Long): Long
+
+  @native def approx_n_unique(ptr: Long): Long
+
+  @native def null_count(ptr: Long): Long
+
+  @native def first(ptr: Long): Long
+
+  @native def last(ptr: Long): Long
+
+  @native def quantile(ptr: Long, q: Double, method: String): Long
+
+  @native def arg_min(ptr: Long): Long
+
+  @native def arg_max(ptr: Long): Long
+
+  @native def arg_sort(ptr: Long, descending: Boolean, nullsLast: Boolean): Long
+
+  @native def skew(ptr: Long, bias: Boolean): Long
+
+  @native def kurtosis(ptr: Long, fisher: Boolean, bias: Boolean): Long
+
   @native def free(ptr: Long): Unit
 
 }

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/functions_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/functions_expr.scala
@@ -1,0 +1,19 @@
+package com.github.chitralverma.polars.internal.jni.expressions
+
+import com.github.chitralverma.polars.internal.jni.Natively
+
+private[polars] object functions_expr extends Natively {
+
+  @native def any_horizontal(ptrs: Array[Long]): Long
+
+  @native def all_horizontal(ptrs: Array[Long]): Long
+
+  @native def max_horizontal(ptrs: Array[Long]): Long
+
+  @native def min_horizontal(ptrs: Array[Long]): Long
+
+  @native def sum_horizontal(ptrs: Array[Long], ignoreNulls: Boolean): Long
+
+  @native def mean_horizontal(ptrs: Array[Long], ignoreNulls: Boolean): Long
+
+}

--- a/core/src/test/java/com/github/chitralverma/polars/AggregationTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/AggregationTest.java
@@ -1,0 +1,119 @@
+package com.github.chitralverma.polars;
+
+import static com.github.chitralverma.polars.functions.*;
+
+import com.github.chitralverma.polars.api.DataFrame;
+import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
+import org.junit.Test;
+
+/**
+ * Java mirror of {@code AggregationSuite}. Replicates and asserts behaviours tested in upstream
+ * py-polars for core expression-level and horizontal aggregations in Java.
+ */
+public class AggregationTest extends AbstractPolarsJavaTest {
+
+  @Test
+  public void expressionLevelReductions() {
+    DataFrame df = intFrame("ColX", 1, 2, 3, 4);
+
+    // sum, min, max, mean, median
+    assertColumnValues(df.select(col("ColX").sum().alias("sum")), "sum", 10);
+    assertColumnValues(df.select(col("ColX").min().alias("min")), "min", 1);
+    assertColumnValues(df.select(col("ColX").max().alias("max")), "max", 4);
+    assertColumnValues(df.select(col("ColX").mean().alias("mean")), "mean", 2.5);
+    assertColumnValues(df.select(col("ColX").median().alias("median")), "median", 2.5);
+
+    // std, var (ddof default = 1)
+    assertColumnValues(df.select(col("ColX").std().alias("std")), "std", 1.2909944487358056);
+    assertColumnValues(df.select(col("ColX").var().alias("var")), "var", 1.6666666666666667);
+    assertColumnValues(df.select(col("ColX").variance().alias("var")), "var", 1.6666666666666667);
+
+    // product, count, len, nUnique, approxNUnique, nullCount
+    assertColumnValues(df.select(col("ColX").product().alias("prod")), "prod", 24L);
+    assertColumnValues(df.select(col("ColX").count().alias("count")), "count", 4);
+    assertColumnValues(df.select(col("ColX").len().alias("len")), "len", 4);
+    assertColumnValues(df.select(col("ColX").nUnique().alias("n_uniq")), "n_uniq", 4);
+    assertColumnValues(df.select(col("ColX").approxNUnique().alias("approx")), "approx", 4);
+    assertColumnValues(df.select(col("ColX").nullCount().alias("nulls")), "nulls", 0);
+
+    // first, last
+    assertColumnValues(df.select(col("ColX").first().alias("first")), "first", 1);
+    assertColumnValues(df.select(col("ColX").last().alias("last")), "last", 4);
+  }
+
+  @Test
+  public void expressionLevelSortingAndQuantiles() {
+    DataFrame df = intFrame("ColX", 3, 1, 4, 2);
+
+    // argMin, argMax
+    assertColumnValues(df.select(col("ColX").argMin().alias("argmin")), "argmin", 1);
+    assertColumnValues(df.select(col("ColX").argMax().alias("argmax")), "argmax", 2);
+
+    // argSort
+    DataFrame dfSort = df.select(col("ColX").argSort().alias("sort_idx"));
+    assertColumnValues(dfSort, "sort_idx", 1, 3, 0, 2);
+
+    // skew, kurtosis
+    assertColumnValues(df.select(col("ColX").skew().alias("skew")), "skew", 0.0);
+    assertColumnValues(df.select(col("ColX").kurtosis().alias("kurt")), "kurt", -1.36);
+
+    // quantile (Nearest/Linear)
+    assertColumnValues(df.select(col("ColX").quantile(0.5, "nearest").alias("q")), "q", 3.0);
+    assertColumnValues(df.select(col("ColX").quantile(0.5, "linear").alias("q")), "q", 2.5);
+  }
+
+  @Test
+  public void freeCompanionFunctions() {
+    DataFrame df = intFrame("ColX", 1, 2, 3, 4);
+
+    // sum, min, max, mean, median, std, var, count, nUnique, approxNUnique, first, last, quantile
+    assertColumnValues(df.select(sum("ColX").alias("sum")), "sum", 10);
+    assertColumnValues(df.select(min("ColX").alias("min")), "min", 1);
+    assertColumnValues(df.select(max("ColX").alias("max")), "max", 4);
+    assertColumnValues(df.select(mean("ColX").alias("mean")), "mean", 2.5);
+    assertColumnValues(df.select(median("ColX").alias("median")), "median", 2.5);
+    assertColumnValues(df.select(std("ColX").alias("std")), "std", 1.2909944487358056);
+    assertColumnValues(df.select(variance("ColX").alias("var")), "var", 1.6666666666666667);
+    assertColumnValues(df.select(count("ColX").alias("count")), "count", 4);
+    assertColumnValues(df.select(nUnique("ColX").alias("n_uniq")), "n_uniq", 4);
+    assertColumnValues(df.select(approxNUnique("ColX").alias("approx")), "approx", 4);
+    assertColumnValues(df.select(first("ColX").alias("first")), "first", 1);
+    assertColumnValues(df.select(last("ColX").alias("last")), "last", 4);
+    assertColumnValues(df.select(quantile("ColX", 0.5, "linear").alias("q")), "q", 2.5);
+
+    // len() free function
+    assertColumnValues(df.select(len().alias("total_rows")), "total_rows", 4);
+  }
+
+  @Test
+  public void horizontalAggregates() {
+    DataFrame df = intFrame("A", 1, 2, 3).withColumn("B", col("A").multiply(10));
+
+    // sumHorizontal, meanHorizontal
+    DataFrame dfSum = df.select(sumHorizontal(col("A"), col("B")).alias("sum_h"));
+    assertColumnValues(dfSum, "sum_h", 11, 22, 33);
+
+    DataFrame dfMean = df.select(meanHorizontal(col("A"), col("B")).alias("mean_h"));
+    assertColumnValues(dfMean, "mean_h", 5.5, 11.0, 16.5);
+
+    // minHorizontal, maxHorizontal
+    DataFrame dfMin = df.select(minHorizontal(col("A"), col("B")).alias("min_h"));
+    assertColumnValues(dfMin, "min_h", 1, 2, 3);
+
+    DataFrame dfMax = df.select(maxHorizontal(col("A"), col("B")).alias("max_h"));
+    assertColumnValues(dfMax, "max_h", 10, 20, 30);
+
+    // boolean horizontals
+    DataFrame dfBase = intFrame("ColX", 2, 2, 3, 1);
+    DataFrame dfBool =
+        dfBase
+            .withColumn("A_bool", col("ColX").equalTo(2)) // [true, true, false, false]
+            .withColumn("B_bool", col("ColX").greaterThanEqualTo(2)); // [true, true, true, false]
+
+    DataFrame dfAny = dfBool.select(anyHorizontal(col("A_bool"), col("B_bool")).alias("any_h"));
+    assertColumnValues(dfAny, "any_h", true, true, true, false);
+
+    DataFrame dfAll = dfBool.select(allHorizontal(col("A_bool"), col("B_bool")).alias("all_h"));
+    assertColumnValues(dfAll, "all_h", true, true, false, false);
+  }
+}

--- a/core/src/test/java/com/github/chitralverma/polars/AggregationTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/AggregationTest.java
@@ -39,6 +39,30 @@ public class AggregationTest extends AbstractPolarsJavaTest {
     // first, last
     assertColumnValues(df.select(col("ColX").first().alias("first")), "first", 1);
     assertColumnValues(df.select(col("ColX").last().alias("last")), "last", 4);
+
+    // any, all (on boolean expression), cumSum
+    DataFrame dfBool =
+        df.select(col("ColX").greaterThan(2).alias("b")); // [false, false, true, true]
+    assertColumnValues(dfBool.select(col("b").any().alias("any_b")), "any_b", true);
+    assertColumnValues(dfBool.select(col("b").all().alias("all_b")), "all_b", false);
+
+    DataFrame dfCum = df.select(col("ColX").cumSum().alias("cum_sum"));
+    assertColumnValues(dfCum, "cum_sum", 1, 3, 6, 10);
+
+    // Test ddof validation (Copilot check)
+    try {
+      col("ColX").std(-1);
+      org.junit.Assert.fail("Expected IllegalArgumentException for ddof < 0");
+    } catch (IllegalArgumentException e) {
+      org.junit.Assert.assertTrue(e.getMessage().contains("must be between 0 and 255"));
+    }
+
+    try {
+      col("ColX").var(256);
+      org.junit.Assert.fail("Expected IllegalArgumentException for ddof > 255");
+    } catch (IllegalArgumentException e) {
+      org.junit.Assert.assertTrue(e.getMessage().contains("must be between 0 and 255"));
+    }
   }
 
   @Test
@@ -66,7 +90,8 @@ public class AggregationTest extends AbstractPolarsJavaTest {
   public void freeCompanionFunctions() {
     DataFrame df = intFrame("ColX", 1, 2, 3, 4);
 
-    // sum, min, max, mean, median, std, var, count, nUnique, approxNUnique, first, last, quantile
+    // sum, min, max, mean, median, std, var, count, nUnique, approxNUnique, first, last, quantile,
+    // any, all, cumSum
     assertColumnValues(df.select(sum("ColX").alias("sum")), "sum", 10);
     assertColumnValues(df.select(min("ColX").alias("min")), "min", 1);
     assertColumnValues(df.select(max("ColX").alias("max")), "max", 4);
@@ -80,6 +105,12 @@ public class AggregationTest extends AbstractPolarsJavaTest {
     assertColumnValues(df.select(first("ColX").alias("first")), "first", 1);
     assertColumnValues(df.select(last("ColX").alias("last")), "last", 4);
     assertColumnValues(df.select(quantile("ColX", 0.5, "linear").alias("q")), "q", 2.5);
+
+    DataFrame dfBool = df.select(col("ColX").greaterThan(2).alias("b"));
+    assertColumnValues(dfBool.select(any("b").alias("any_b")), "any_b", true);
+    assertColumnValues(dfBool.select(all("b").alias("all_b")), "all_b", false);
+
+    assertColumnValues(df.select(cumSum("ColX").alias("cum_sum")), "cum_sum", 1, 3, 6, 10);
 
     // len() free function
     assertColumnValues(df.select(len().alias("total_rows")), "total_rows", 4);
@@ -115,5 +146,80 @@ public class AggregationTest extends AbstractPolarsJavaTest {
 
     DataFrame dfAll = dfBool.select(allHorizontal(col("A_bool"), col("B_bool")).alias("all_h"));
     assertColumnValues(dfAll, "all_h", true, true, false, false);
+  }
+
+  @Test
+  public void testVerticalAliasForColAgg() {
+    // Replicates test_vertical.py::test_alias_for_col_agg and test_alias_for_col_agg_bool
+    // Skipped: selectors (cs.*), as_expression (not yet supported)
+    DataFrame df = intFrame("a", 1, 4);
+    assertColumnValues(df.select(min("a").alias("m")), "m", 1);
+    assertColumnValues(df.select(max("a").alias("m")), "m", 4);
+    assertColumnValues(df.select(sum("a").alias("m")), "m", 5);
+    assertColumnValues(df.select(cumSum("a").alias("m")), "m", 1, 5);
+
+    DataFrame dfBool = booleanFrame("b", true, false);
+    assertColumnValues(dfBool.select(any("b").alias("any")), "any", true);
+    assertColumnValues(dfBool.select(all("b").alias("all")), "all", false);
+  }
+
+  @Test
+  public void testHorizontalAggregationsEdgeCases() {
+    // Replicates test_horizontal.py::test_max_min_nulls_consistency (using shift for nulls)
+    // Skipped: cum_sum_horizontal (deferred to Phase 10 Structs), pl.duration, Decimal dtypes
+    DataFrame dfNulls =
+        intFrame("a", 10, 20, 30)
+            .withColumn("b", col("a").shift(1)) // [null, 10, 20]
+            .withColumn("c", col("a").shift(-1)); // [20, 30, null]
+    assertColumnValues(
+        dfNulls.select(maxHorizontal(col("a"), col("b"), col("c")).alias("max_h")),
+        "max_h",
+        20,
+        30,
+        30);
+    assertColumnValues(
+        dfNulls.select(minHorizontal(col("a"), col("b"), col("c")).alias("min_h")),
+        "min_h",
+        10,
+        10,
+        20);
+
+    // Replicates test_horizontal.py::test_nested_min_max
+    DataFrame dfNested =
+        intFrame("a", 1).withColumn("b", lit(2)).withColumn("c", lit(3)).withColumn("d", lit(4));
+    DataFrame dfNestedRes =
+        dfNested.select(
+            maxHorizontal(minHorizontal(col("a"), col("b")), minHorizontal(col("c"), col("d")))
+                .alias("t"));
+    assertColumnValues(dfNestedRes, "t", 3);
+
+    // Replicates test_horizontal.py::test_horizontal_broadcasting
+    DataFrame dfBroad =
+        intFrame("a", 1, 3).withColumn("b", lit(3)); // b = [3, 3] (literal broadcasted)
+    assertColumnValues(
+        dfBroad.select(sumHorizontal(lit(1), col("a"), col("b")).alias("sum_h")), "sum_h", 5, 7);
+
+    // Replicates test_horizontal.py::test_mean_horizontal_bool
+    DataFrame dfBoolMean =
+        booleanFrame("a", true, false, false)
+            .withColumn("b", col("a").reverse()); // [false, false, true]
+    assertColumnValues(
+        dfBoolMean.select(meanHorizontal(col("a"), col("b")).alias("mean_h")),
+        "mean_h",
+        0.5,
+        0.0,
+        0.5);
+
+    // Replicates test_horizontal.py::test_raise_invalid_types_21835
+    DataFrame dfInvalid =
+        DataFrame.fromSeries(
+            com.github.chitralverma.polars.api.Series.ofInt("x", new int[] {1}),
+            com.github.chitralverma.polars.api.Series.ofString("y", new String[] {"two"}));
+    try {
+      dfInvalid.select(minHorizontal(col("x"), col("y")));
+      org.junit.Assert.fail("Expected RuntimeException for invalid horizontal min types");
+    } catch (RuntimeException e) {
+      // Expected native-side validation panic
+    }
   }
 }

--- a/core/src/test/scala/com/github/chitralverma/polars/AggregationSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/AggregationSuite.scala
@@ -34,6 +34,22 @@ class AggregationSuite extends PolarsTestBase {
     // first, last
     assertColumnValues(df.select(col("ColX").first().alias("first")), "first", 1)
     assertColumnValues(df.select(col("ColX").last().alias("last")), "last", 4)
+
+    // any, all (on boolean expression), cumSum
+    val dfBool = df.select((col("ColX") > 2).alias("b")) // [false, false, true, true]
+    assertColumnValues(dfBool.select(col("b").any().alias("any_b")), "any_b", true)
+    assertColumnValues(dfBool.select(col("b").all().alias("all_b")), "all_b", false)
+
+    val dfCum = df.select(col("ColX").cumSum().alias("cum_sum"))
+    assertColumnValues(dfCum, "cum_sum", 1, 3, 6, 10)
+
+    // Test ddof validation (Copilot check)
+    an[IllegalArgumentException] shouldBe thrownBy {
+      col("ColX").std(-1)
+    }
+    an[IllegalArgumentException] shouldBe thrownBy {
+      col("ColX").`var`(256)
+    }
   }
 
   test("expression-level indexing, sorting, shape, and quantile reductions") {
@@ -59,7 +75,7 @@ class AggregationSuite extends PolarsTestBase {
   test("free companion functions mirroring pl.*") {
     val df = intFrame("ColX", 1, 2, 3, 4)
 
-    // sum, min, max, mean, median, std, var, count, nUnique, approxNUnique, first, last, quantile
+    // sum, min, max, mean, median, std, var, count, nUnique, approxNUnique, first, last, quantile, any, all, cumSum
     assertColumnValues(df.select(sum("ColX").alias("sum")), "sum", 10)
     assertColumnValues(df.select(min("ColX").alias("min")), "min", 1)
     assertColumnValues(df.select(max("ColX").alias("max")), "max", 4)
@@ -74,11 +90,19 @@ class AggregationSuite extends PolarsTestBase {
     assertColumnValues(df.select(last("ColX").alias("last")), "last", 4)
     assertColumnValues(df.select(quantile("ColX", 0.5, "linear").alias("q")), "q", 2.5)
 
+    val dfBool = df.select((col("ColX") > 2).alias("b"))
+    assertColumnValues(dfBool.select(any("b").alias("any_b")), "any_b", true)
+    assertColumnValues(dfBool.select(functions.all("b").alias("all_b")), "all_b", false)
+
+    assertColumnValues(df.select(cumSum("ColX").alias("cum_sum")), "cum_sum", 1, 3, 6, 10)
+
     // len() free function row-count helper
     assertColumnValues(df.select(len().alias("total_rows")), "total_rows", 4)
   }
 
-  test("horizontal aggregates: sumHorizontal, meanHorizontal, minHorizontal, maxHorizontal, allHorizontal, anyHorizontal") {
+  test(
+    "horizontal aggregates: sumHorizontal, meanHorizontal, minHorizontal, maxHorizontal, allHorizontal, anyHorizontal"
+  ) {
     val df = intFrame("A", 1, 2, 3).withColumn("B", col("A") * 10) // B = [10, 20, 30]
 
     // sumHorizontal, meanHorizontal
@@ -106,6 +130,80 @@ class AggregationSuite extends PolarsTestBase {
 
     val dfAll = dfBool.select(allHorizontal(col("A_bool"), col("B_bool")).alias("all_h"))
     assertColumnValues(dfAll, "all_h", true, true, false, false)
+  }
+
+  test("test_vertical: alias for col agg (equivalence of free-fn and expr form)") {
+    // Replicates test_vertical.py::test_alias_for_col_agg and test_alias_for_col_agg_bool
+    // Skipped: selectors (cs.*), as_expression (not yet supported)
+    val df = intFrame("a", 1, 4)
+    assertColumnValues(df.select(min("a").alias("m")), "m", 1)
+    assertColumnValues(df.select(max("a").alias("m")), "m", 4)
+    assertColumnValues(df.select(sum("a").alias("m")), "m", 5)
+    assertColumnValues(df.select(cumSum("a").alias("m")), "m", 1, 5)
+
+    val dfBool = booleanFrame("b", true, false)
+    assertColumnValues(dfBool.select(any("b").alias("any")), "any", true)
+    assertColumnValues(dfBool.select(functions.all("b").alias("all")), "all", false)
+  }
+
+  test("test_horizontal: max_min_nulls_consistency, nested_min_max, broadcasting, and raises") {
+    // Replicates test_horizontal.py::test_max_min_nulls_consistency (using shift for nulls)
+    // Skipped: cum_sum_horizontal (deferred to Phase 10 Structs), pl.duration, Decimal dtypes
+    val dfNulls = intFrame("a", 10, 20, 30)
+      .withColumn("b", col("a").shift(1)) // [null, 10, 20]
+      .withColumn("c", col("a").shift(-1)) // [20, 30, null]
+    assertColumnValues(
+      dfNulls.select(maxHorizontal(col("a"), col("b"), col("c")).alias("max_h")),
+      "max_h",
+      20,
+      30,
+      30
+    )
+    assertColumnValues(
+      dfNulls.select(minHorizontal(col("a"), col("b"), col("c")).alias("min_h")),
+      "min_h",
+      10,
+      10,
+      20
+    )
+
+    // Replicates test_horizontal.py::test_nested_min_max
+    val dfNested =
+      intFrame("a", 1).withColumn("b", lit(2)).withColumn("c", lit(3)).withColumn("d", lit(4))
+    val dfNestedRes = dfNested.select(
+      maxHorizontal(minHorizontal(col("a"), col("b")), minHorizontal(col("c"), col("d")))
+        .alias("t")
+    )
+    assertColumnValues(dfNestedRes, "t", 3)
+
+    // Replicates test_horizontal.py::test_horizontal_broadcasting
+    val dfBroad = intFrame("a", 1, 3).withColumn("b", lit(3)) // b = [3, 3] (literal broadcasted)
+    assertColumnValues(
+      dfBroad.select(sumHorizontal(lit(1), col("a"), col("b")).alias("sum_h")),
+      "sum_h",
+      5,
+      7
+    )
+
+    // Replicates test_horizontal.py::test_mean_horizontal_bool
+    val dfBoolMean = booleanFrame("a", true, false, false)
+      .withColumn("b", col("a").reverse()) // [false, false, true]
+    assertColumnValues(
+      dfBoolMean.select(meanHorizontal(col("a"), col("b")).alias("mean_h")),
+      "mean_h",
+      0.5,
+      0.0,
+      0.5
+    )
+
+    // Replicates test_horizontal.py::test_raise_invalid_types_21835 (min_horizontal on int and string raises)
+    val dfInvalid = api.DataFrame.fromSeries(
+      api.Series.ofInt("x", Array(1)),
+      api.Series.ofString("y", Array("two"))
+    )
+    assertThrows[RuntimeException] {
+      dfInvalid.select(minHorizontal(col("x"), col("y")))
+    }
   }
 
 }

--- a/core/src/test/scala/com/github/chitralverma/polars/AggregationSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/AggregationSuite.scala
@@ -1,0 +1,111 @@
+package com.github.chitralverma.polars
+
+import com.github.chitralverma.polars.functions._
+import com.github.chitralverma.polars.testing.PolarsTestBase
+
+/** Replicates and asserts behaviours tested in upstream py-polars for core expression-level and
+  * horizontal aggregations.
+  */
+class AggregationSuite extends PolarsTestBase {
+
+  test("expression-level statistical and value reductions") {
+    val df = intFrame("ColX", 1, 2, 3, 4)
+
+    // sum, min, max, mean, median
+    assertColumnValues(df.select(col("ColX").sum().alias("sum")), "sum", 10)
+    assertColumnValues(df.select(col("ColX").min().alias("min")), "min", 1)
+    assertColumnValues(df.select(col("ColX").max().alias("max")), "max", 4)
+    assertColumnValues(df.select(col("ColX").mean().alias("mean")), "mean", 2.5)
+    assertColumnValues(df.select(col("ColX").median().alias("median")), "median", 2.5)
+
+    // std, var (ddof default = 1)
+    assertColumnValues(df.select(col("ColX").std().alias("std")), "std", 1.2909944487358056)
+    assertColumnValues(df.select(col("ColX").`var`().alias("var")), "var", 1.6666666666666667)
+    assertColumnValues(df.select(col("ColX").variance().alias("var")), "var", 1.6666666666666667)
+
+    // product, count, len, nUnique, approxNUnique, nullCount
+    assertColumnValues(df.select(col("ColX").product().alias("prod")), "prod", 24L)
+    assertColumnValues(df.select(col("ColX").count().alias("count")), "count", 4)
+    assertColumnValues(df.select(col("ColX").len().alias("len")), "len", 4)
+    assertColumnValues(df.select(col("ColX").nUnique().alias("n_uniq")), "n_uniq", 4)
+    assertColumnValues(df.select(col("ColX").approxNUnique().alias("approx")), "approx", 4)
+    assertColumnValues(df.select(col("ColX").nullCount().alias("nulls")), "nulls", 0)
+
+    // first, last
+    assertColumnValues(df.select(col("ColX").first().alias("first")), "first", 1)
+    assertColumnValues(df.select(col("ColX").last().alias("last")), "last", 4)
+  }
+
+  test("expression-level indexing, sorting, shape, and quantile reductions") {
+    val df = intFrame("ColX", 3, 1, 4, 2)
+
+    // argMin, argMax
+    assertColumnValues(df.select(col("ColX").argMin().alias("argmin")), "argmin", 1)
+    assertColumnValues(df.select(col("ColX").argMax().alias("argmax")), "argmax", 2)
+
+    // argSort
+    val dfSort = df.select(col("ColX").argSort().alias("sort_idx"))
+    assertColumnValues(dfSort, "sort_idx", 1, 3, 0, 2) // sorts to indices [1, 3, 0, 2]
+
+    // skew, kurtosis
+    assertColumnValues(df.select(col("ColX").skew().alias("skew")), "skew", 0.0)
+    assertColumnValues(df.select(col("ColX").kurtosis().alias("kurt")), "kurt", -1.36)
+
+    // quantile (Nearest/Linear)
+    assertColumnValues(df.select(col("ColX").quantile(0.5, "nearest").alias("q")), "q", 3.0)
+    assertColumnValues(df.select(col("ColX").quantile(0.5, "linear").alias("q")), "q", 2.5)
+  }
+
+  test("free companion functions mirroring pl.*") {
+    val df = intFrame("ColX", 1, 2, 3, 4)
+
+    // sum, min, max, mean, median, std, var, count, nUnique, approxNUnique, first, last, quantile
+    assertColumnValues(df.select(sum("ColX").alias("sum")), "sum", 10)
+    assertColumnValues(df.select(min("ColX").alias("min")), "min", 1)
+    assertColumnValues(df.select(max("ColX").alias("max")), "max", 4)
+    assertColumnValues(df.select(mean("ColX").alias("mean")), "mean", 2.5)
+    assertColumnValues(df.select(median("ColX").alias("median")), "median", 2.5)
+    assertColumnValues(df.select(std("ColX").alias("std")), "std", 1.2909944487358056)
+    assertColumnValues(df.select(variance("ColX").alias("var")), "var", 1.6666666666666667)
+    assertColumnValues(df.select(count("ColX").alias("count")), "count", 4)
+    assertColumnValues(df.select(nUnique("ColX").alias("n_uniq")), "n_uniq", 4)
+    assertColumnValues(df.select(approxNUnique("ColX").alias("approx")), "approx", 4)
+    assertColumnValues(df.select(first("ColX").alias("first")), "first", 1)
+    assertColumnValues(df.select(last("ColX").alias("last")), "last", 4)
+    assertColumnValues(df.select(quantile("ColX", 0.5, "linear").alias("q")), "q", 2.5)
+
+    // len() free function row-count helper
+    assertColumnValues(df.select(len().alias("total_rows")), "total_rows", 4)
+  }
+
+  test("horizontal aggregates: sumHorizontal, meanHorizontal, minHorizontal, maxHorizontal, allHorizontal, anyHorizontal") {
+    val df = intFrame("A", 1, 2, 3).withColumn("B", col("A") * 10) // B = [10, 20, 30]
+
+    // sumHorizontal, meanHorizontal
+    val dfSum = df.select(sumHorizontal(col("A"), col("B")).alias("sum_h"))
+    assertColumnValues(dfSum, "sum_h", 11, 22, 33)
+
+    val dfMean = df.select(meanHorizontal(col("A"), col("B")).alias("mean_h"))
+    assertColumnValues(dfMean, "mean_h", 5.5, 11.0, 16.5)
+
+    // minHorizontal, maxHorizontal
+    val dfMin = df.select(minHorizontal(col("A"), col("B")).alias("min_h"))
+    assertColumnValues(dfMin, "min_h", 1, 2, 3)
+
+    val dfMax = df.select(maxHorizontal(col("A"), col("B")).alias("max_h"))
+    assertColumnValues(dfMax, "max_h", 10, 20, 30)
+
+    // boolean horizontals
+    val dfBase = intFrame("ColX", 2, 2, 3, 1)
+    val dfBool = dfBase
+      .withColumn("A_bool", col("ColX") === 2) // [true, true, false, false]
+      .withColumn("B_bool", col("ColX") >= 2) // [true, true, true, false]
+
+    val dfAny = dfBool.select(anyHorizontal(col("A_bool"), col("B_bool")).alias("any_h"))
+    assertColumnValues(dfAny, "any_h", true, true, true, false)
+
+    val dfAll = dfBool.select(allHorizontal(col("A_bool"), col("B_bool")).alias("all_h"))
+    assertColumnValues(dfAll, "all_h", true, true, false, false)
+  }
+
+}

--- a/native/src/internal_jni/expr/column.rs
+++ b/native/src/internal_jni/expr/column.rs
@@ -3,7 +3,7 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 use anyhow::Context;
 use jni::JNIEnv;
 use jni::objects::{JClass, JObject, JObjectArray, JString};
-use jni::sys::{jint, jlong};
+use jni::sys::{jdouble, jint, jlong};
 use jni_fn::jni_fn;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -508,6 +508,154 @@ pub fn mode(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
 pub fn unique_counts(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
     let l_expr = from_ptr(expr_ptr);
     to_ptr(l_expr.unique_counts())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn sum(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.sum())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn min(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.min())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn max(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.max())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn mean(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.mean())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn median(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.median())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn std(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, ddof: jint) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.std(ddof as u8))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn var(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, ddof: jint) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.var(ddof as u8))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn product(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.product())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn count(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.count())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn len(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.len())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn n_unique(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.n_unique())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn approx_n_unique(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.approx_n_unique())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn null_count(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.null_count())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn first(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.first())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn last(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.last())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn quantile(
+    mut env: JNIEnv,
+    _: JClass,
+    expr_ptr: *mut Expr,
+    q: jdouble,
+    method: JString,
+) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    let s_method = j_string_to_string(&mut env, &method, Some("Failed to parse quantile method"));
+    let q_method = match s_method.to_lowercase().as_str() {
+        "nearest" => QuantileMethod::Nearest,
+        "lower" => QuantileMethod::Lower,
+        "higher" => QuantileMethod::Higher,
+        "midpoint" => QuantileMethod::Midpoint,
+        "linear" => QuantileMethod::Linear,
+        "equiprobable" => QuantileMethod::Equiprobable,
+        _ => QuantileMethod::Nearest,
+    };
+    to_ptr(l_expr.quantile(lit(q), q_method))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn arg_min(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.arg_min())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn arg_max(_: JNIEnv, _: JClass, expr_ptr: *mut Expr) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.arg_max())
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn arg_sort(
+    _: JNIEnv,
+    _: JClass,
+    expr_ptr: *mut Expr,
+    descending: bool,
+    nulls_last: bool,
+) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.arg_sort(descending, nulls_last))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn skew(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, bias: bool) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.skew(bias))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn kurtosis(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, fisher: bool, bias: bool) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.kurtosis(fisher, bias))
 }
 
 #[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]

--- a/native/src/internal_jni/expr/column.rs
+++ b/native/src/internal_jni/expr/column.rs
@@ -659,6 +659,24 @@ pub fn kurtosis(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, fisher: bool, bias: b
 }
 
 #[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn any(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, ignore_nulls: bool) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.any(ignore_nulls))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn all(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, ignore_nulls: bool) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.all(ignore_nulls))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
+pub fn cum_sum(_: JNIEnv, _: JClass, expr_ptr: *mut Expr, reverse: bool) -> jlong {
+    let l_expr = from_ptr(expr_ptr);
+    to_ptr(l_expr.cum_sum(reverse))
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.column_expr$")]
 pub fn free(_: JNIEnv, _: JClass, ptr: jlong) {
     free_ptr::<Expr>(ptr);
 }

--- a/native/src/internal_jni/expr/functions.rs
+++ b/native/src/internal_jni/expr/functions.rs
@@ -1,0 +1,96 @@
+use anyhow::Context;
+use jni::JNIEnv;
+use jni::objects::{JClass, JLongArray};
+use jni::sys::jlong;
+use jni_fn::jni_fn;
+use polars_plan::dsl::functions::{
+    all_horizontal, any_horizontal, max_horizontal, mean_horizontal, min_horizontal, sum_horizontal,
+};
+use polars_plan::prelude::Expr;
+
+use crate::internal_jni::conversion::JavaArrayToVec;
+use crate::internal_jni::utils::{from_ptr, to_ptr};
+use crate::utils::error::ResultExt;
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.functions_expr$")]
+pub fn any_horizontal(mut env: JNIEnv, _: JClass, inputs: JLongArray) -> jlong {
+    let exprs: Vec<Expr> = JavaArrayToVec::to_vec(&mut env, inputs)
+        .into_iter()
+        .map(|ptr| (from_ptr(ptr as *mut Expr)).to_owned())
+        .collect();
+
+    let expr = any_horizontal(exprs)
+        .context("Failed to run any_horizontal")
+        .unwrap_or_throw(&mut env);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.functions_expr$")]
+pub fn all_horizontal(mut env: JNIEnv, _: JClass, inputs: JLongArray) -> jlong {
+    let exprs: Vec<Expr> = JavaArrayToVec::to_vec(&mut env, inputs)
+        .into_iter()
+        .map(|ptr| (from_ptr(ptr as *mut Expr)).to_owned())
+        .collect();
+
+    let expr = all_horizontal(exprs)
+        .context("Failed to run all_horizontal")
+        .unwrap_or_throw(&mut env);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.functions_expr$")]
+pub fn max_horizontal(mut env: JNIEnv, _: JClass, inputs: JLongArray) -> jlong {
+    let exprs: Vec<Expr> = JavaArrayToVec::to_vec(&mut env, inputs)
+        .into_iter()
+        .map(|ptr| (from_ptr(ptr as *mut Expr)).to_owned())
+        .collect();
+
+    let expr = max_horizontal(exprs)
+        .context("Failed to run max_horizontal")
+        .unwrap_or_throw(&mut env);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.functions_expr$")]
+pub fn min_horizontal(mut env: JNIEnv, _: JClass, inputs: JLongArray) -> jlong {
+    let exprs: Vec<Expr> = JavaArrayToVec::to_vec(&mut env, inputs)
+        .into_iter()
+        .map(|ptr| (from_ptr(ptr as *mut Expr)).to_owned())
+        .collect();
+
+    let expr = min_horizontal(exprs)
+        .context("Failed to run min_horizontal")
+        .unwrap_or_throw(&mut env);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.functions_expr$")]
+pub fn sum_horizontal(mut env: JNIEnv, _: JClass, inputs: JLongArray, ignore_nulls: bool) -> jlong {
+    let exprs: Vec<Expr> = JavaArrayToVec::to_vec(&mut env, inputs)
+        .into_iter()
+        .map(|ptr| (from_ptr(ptr as *mut Expr)).to_owned())
+        .collect();
+
+    let expr = sum_horizontal(exprs, ignore_nulls)
+        .context("Failed to run sum_horizontal")
+        .unwrap_or_throw(&mut env);
+    to_ptr(expr)
+}
+
+#[jni_fn("com.github.chitralverma.polars.internal.jni.expressions.functions_expr$")]
+pub fn mean_horizontal(
+    mut env: JNIEnv,
+    _: JClass,
+    inputs: JLongArray,
+    ignore_nulls: bool,
+) -> jlong {
+    let exprs: Vec<Expr> = JavaArrayToVec::to_vec(&mut env, inputs)
+        .into_iter()
+        .map(|ptr| (from_ptr(ptr as *mut Expr)).to_owned())
+        .collect();
+
+    let expr = mean_horizontal(exprs, ignore_nulls)
+        .context("Failed to run mean_horizontal")
+        .unwrap_or_throw(&mut env);
+    to_ptr(expr)
+}

--- a/native/src/internal_jni/expr/mod.rs
+++ b/native/src/internal_jni/expr/mod.rs
@@ -1,3 +1,4 @@
 pub mod column;
+pub mod functions;
 pub mod literal;
 pub mod name;


### PR DESCRIPTION
This pull request adds many aggregation methods and free functions. It makes it easy to reduce and sort column values.

### What is new?

- **Aggregations**: Added helpers to find the sum, mean, median, min, or max.
- **Quantiles**: Added `.quantile` with nearest or linear interpolation.
- **Indices**: Added `.argMin`, `.argMax`, and `.argSort`.
- **Horizontals**: Added `sumHorizontal` and `meanHorizontal` for row-wise reductions.
- **Verticals**: Added `any`, `all`, and `cumSum` vertical reductions and free functions.
- **Validation**: Added argument checks in `gatherEvery` to reject negative step sizes, and in `std`/`var` to reject `ddof` values outside `0..=255`. This stops native JNI crashes or numeric wraps.
- **Tests**: Added full tests for both Scala and Java. All 46 tests pass.

### Added Functions & Namespaces

| Method / Namespace | Category | Return Type | Description |
|---|---|---|---|
| `sum` | Expr / Free Aggregation | `Column` | Sum of all values |
| `min` | Expr / Free Aggregation | `Column` | Minimal value |
| `max` | Expr / Free Aggregation | `Column` | Maximum value |
| `mean` | Expr / Free Aggregation | `Column` | Mean of all values |
| `median` | Expr / Free Aggregation | `Column` | Median of all values |
| `std` | Expr / Free Aggregation | `Column` | Standard deviation (with `ddof` range checks) |
| `var` / `variance` | Expr / Free Aggregation | `Column` | Variance of all values (with `ddof` range checks) |
| `product` | Expr / Free Aggregation | `Column` | Product of all values |
| `count` | Expr / Free Aggregation | `Column` | Count non-null values |
| `len` | Expr / Free Aggregation | `Column` | Count all rows (including nulls) |
| `nUnique` | Expr / Free Aggregation | `Column` | Count unique values |
| `approxNUnique` | Expr / Free Aggregation | `Column` | Count approximate unique values |
| `nullCount` | Expr / Free Aggregation | `Column` | Count null values |
| `first` | Expr / Free Aggregation | `Column` | Return first value |
| `last` | Expr / Free Aggregation | `Column` | Return last value |
| `quantile` | Expr / Free Aggregation | `Column` | Return quantile value |
| `argMin` | Expr / Free Aggregation | `Column` | Return index of minimum value |
| `argMax` | Expr / Free Aggregation | `Column` | Return index of maximum value |
| `argSort` | Expr / Free Aggregation | `Column` | Return sorting indices |
| `skew` | Expr / Free Aggregation | `Column` | Return skewness |
| `kurtosis` | Expr / Free Aggregation | `Column` | Return kurtosis |
| `any` | Expr / Free Aggregation | `Column` | Return true if any boolean is true |
| `all` | Expr / Free Aggregation | `Column` | Return true if all booleans are true |
| `cumSum` | Expr / Free Aggregation | `Column` | Cumulative sum of values |
| `anyHorizontal` | Horizontal Aggregation | `Column` | Row-wise boolean any |
| `allHorizontal` | Horizontal Aggregation | `Column` | Row-wise boolean all |
| `maxHorizontal` | Horizontal Aggregation | `Column` | Row-wise maximum |
| `minHorizontal` | Horizontal Aggregation | `Column` | Row-wise minimum |
| `sumHorizontal` | Horizontal Aggregation | `Column` | Row-wise sum |
| `meanHorizontal` | Horizontal Aggregation | `Column` | Row-wise mean |

**Total Functions / Namespaces Added**: 30

This PR has no extra dependencies and is completely green.