### PR TITLE
fix: resolve JNI error abort during test execution

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::expect_fun_call)]
+#![feature(min_specialization)]
 
 use anyhow::Context;
 use internal_jni::utils::{j_string_to_string, string_to_j_string};

--- a/native/src/utils/error.rs
+++ b/native/src/utils/error.rs
@@ -1,8 +1,7 @@
 use anyhow::Error;
-use jni::JNIEnv;
 use jni::errors::Result as JniResult;
-
-use crate::internal_jni::utils::find_java_class;
+use jni::{JNIEnv, sys};
+use polars::prelude::{DataFrame, Expr, LazyFrame, Series};
 
 fn format_nested_error(error: &Error) -> String {
     let mut formatted = String::new();
@@ -19,8 +18,8 @@ fn format_nested_error(error: &Error) -> String {
 }
 
 pub fn throw_java_exception(env: &mut JNIEnv, err: Error) -> JniResult<()> {
-    // Find the Java exception class
-    let exception_class = find_java_class(env, "java/lang/RuntimeException");
+    // Find the Java exception class directly to avoid recursion
+    let exception_class = env.find_class("java/lang/RuntimeException")?;
 
     // Throw the exception with the provided message
     env.throw_new(exception_class, format_nested_error(&err))?;
@@ -32,18 +31,119 @@ pub trait ResultExt<T> {
     fn unwrap_or_throw(self, env: &mut JNIEnv) -> T;
 }
 
+// 1. Default/fallback implementation: throw exception and abort.
 impl<T> ResultExt<T> for Result<T, Error> {
-    fn unwrap_or_throw(self, env: &mut JNIEnv) -> T {
+    default fn unwrap_or_throw(self, env: &mut JNIEnv) -> T {
         match self {
             Ok(val) => val,
             Err(err) => {
-                // Map the error to a Java exception
-                let _ = throw_java_exception(env, err);
-
-                // Exit early by returning a default value for JNI
-                env.exception_describe().unwrap_or(());
+                if !env.exception_check().unwrap_or(false) {
+                    let _ = throw_java_exception(env, err);
+                }
                 std::process::abort();
             },
         }
+    }
+}
+
+// 2. Specialized implementations for primitive/Default types:
+macro_rules! impl_result_ext_safe {
+    ($t:ty, $def:expr) => {
+        impl ResultExt<$t> for Result<$t, Error> {
+            fn unwrap_or_throw(self, env: &mut JNIEnv) -> $t {
+                match self {
+                    Ok(val) => val,
+                    Err(err) => {
+                        if !env.exception_check().unwrap_or(false) {
+                            let _ = throw_java_exception(env, err);
+                        }
+                        $def
+                    },
+                }
+            }
+        }
+    };
+}
+
+impl_result_ext_safe!(i64, 0);
+impl_result_ext_safe!(i32, 0);
+impl_result_ext_safe!(u8, 0);
+impl_result_ext_safe!((), ());
+impl_result_ext_safe!(f64, 0.0);
+impl_result_ext_safe!(f32, 0.0);
+impl_result_ext_safe!(bool, false);
+impl_result_ext_safe!(sys::jobject, std::ptr::null_mut());
+impl_result_ext_safe!(DataFrame, DataFrame::default());
+impl_result_ext_safe!(LazyFrame, LazyFrame::default());
+impl_result_ext_safe!(Series, Series::default());
+impl_result_ext_safe!(Expr, Expr::default());
+
+impl<'local> ResultExt<jni::objects::JObject<'local>>
+    for Result<jni::objects::JObject<'local>, Error>
+{
+    fn unwrap_or_throw(self, env: &mut JNIEnv) -> jni::objects::JObject<'local> {
+        match self {
+            Ok(val) => val,
+            Err(err) => {
+                if !env.exception_check().unwrap_or(false) {
+                    let _ = throw_java_exception(env, err);
+                }
+                jni::objects::JObject::null()
+            },
+        }
+    }
+}
+
+impl<'local> ResultExt<jni::objects::JString<'local>>
+    for Result<jni::objects::JString<'local>, Error>
+{
+    fn unwrap_or_throw(self, env: &mut JNIEnv) -> jni::objects::JString<'local> {
+        match self {
+            Ok(val) => val,
+            Err(err) => {
+                if !env.exception_check().unwrap_or(false) {
+                    let _ = throw_java_exception(env, err);
+                }
+                jni::objects::JString::from(jni::objects::JObject::null())
+            },
+        }
+    }
+}
+
+impl<'local> ResultExt<jni::objects::JClass<'local>>
+    for Result<jni::objects::JClass<'local>, Error>
+{
+    fn unwrap_or_throw(self, env: &mut JNIEnv) -> jni::objects::JClass<'local> {
+        match self {
+            Ok(val) => val,
+            Err(err) => {
+                if !env.exception_check().unwrap_or(false) {
+                    let _ = throw_java_exception(env, err);
+                }
+                jni::objects::JClass::from(jni::objects::JObject::null())
+            },
+        }
+    }
+}
+
+pub fn catch_unwind_or_throw<T, F>(env: &mut JNIEnv, f: F) -> T
+where
+    F: FnOnce() -> T + std::panic::UnwindSafe,
+    Result<T, Error>: ResultExt<T>,
+{
+    let result = std::panic::catch_unwind(f);
+    match result {
+        Ok(val) => val,
+        Err(err) => {
+            let msg = if let Some(s) = err.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = err.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown Rust panic".to_string()
+            };
+            let anyhow_err = anyhow::anyhow!("Rust Panic: {}", msg);
+            Err(anyhow_err).unwrap_or_throw(env)
+        },
     }
 }


### PR DESCRIPTION
This PR fixes the JNI error-handling contract by using nightly 'min_specialization' to prevent JVM aborts during tests that expect a native RuntimeException.