### PR TITLE
fix(test): unbreak Test/doc in ci-release ($-suffixed companion in Java test)

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Check doc issues
         run: just site
+
+      - name: Check API docs (all Scala versions)
+        run: just check-docs

--- a/core/src/test/java/com/github/chitralverma/polars/NativeLoaderTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/NativeLoaderTest.java
@@ -11,45 +11,44 @@ import org.junit.Test;
  * normalization, classpath resource paths, and the content-addressed extraction cache. Not a port
  * of an upstream pytest.
  *
- * <p>The package-private helpers live on the Scala companion object, so they are reached from Java
- * via {@code NativeLoader$.MODULE$}.
+ * <p>The package-private helpers live on the Scala companion object and are reached from this
+ * same-package Java test through its generated singleton.
  */
 public class NativeLoaderTest {
 
-  private static final NativeLoader$ LOADER = NativeLoader$.MODULE$;
-
   @Test
   public void normalizeArchMapsKnownAliases() {
-    Assert.assertEquals("aarch64", LOADER.normalizeArch("aarch64"));
-    Assert.assertEquals("aarch64", LOADER.normalizeArch("arm64"));
-    Assert.assertEquals("x86_64", LOADER.normalizeArch("amd64"));
-    Assert.assertEquals("x86_64", LOADER.normalizeArch("x86_64"));
+    Assert.assertEquals("aarch64", NativeLoader$.MODULE$.normalizeArch("aarch64"));
+    Assert.assertEquals("aarch64", NativeLoader$.MODULE$.normalizeArch("arm64"));
+    Assert.assertEquals("x86_64", NativeLoader$.MODULE$.normalizeArch("amd64"));
+    Assert.assertEquals("x86_64", NativeLoader$.MODULE$.normalizeArch("x86_64"));
   }
 
   @Test
   public void normalizeArchIsCaseInsensitive() {
-    Assert.assertEquals("aarch64", LOADER.normalizeArch("AArch64"));
-    Assert.assertEquals("x86_64", LOADER.normalizeArch("AMD64"));
+    Assert.assertEquals("aarch64", NativeLoader$.MODULE$.normalizeArch("AArch64"));
+    Assert.assertEquals("x86_64", NativeLoader$.MODULE$.normalizeArch("AMD64"));
   }
 
   @Test
   public void normalizeArchPassesThroughUnknown() {
-    Assert.assertEquals("riscv64", LOADER.normalizeArch("riscv64"));
-    Assert.assertEquals("ppc64le", LOADER.normalizeArch("PPC64LE"));
+    Assert.assertEquals("riscv64", NativeLoader$.MODULE$.normalizeArch("riscv64"));
+    Assert.assertEquals("ppc64le", NativeLoader$.MODULE$.normalizeArch("PPC64LE"));
   }
 
   @Test
   public void resourcePathBuildsBundlePath() {
     String mapped = System.mapLibraryName("scala_polars");
     Assert.assertEquals(
-        "/native/aarch64/" + mapped, LOADER.resourcePath("scala_polars", "aarch64"));
-    Assert.assertEquals("/native/x86_64/" + mapped, LOADER.resourcePath("scala_polars", "x86_64"));
+        "/native/aarch64/" + mapped, NativeLoader$.MODULE$.resourcePath("scala_polars", "aarch64"));
+    Assert.assertEquals(
+        "/native/x86_64/" + mapped, NativeLoader$.MODULE$.resourcePath("scala_polars", "x86_64"));
   }
 
   @Test
   public void extractToCacheWritesExactBytes() throws IOException {
     byte[] bytes = "hello-native-java".getBytes("UTF-8");
-    Path path = LOADER.extractToCache("libtest_extract_java.bin", bytes);
+    Path path = NativeLoader$.MODULE$.extractToCache("libtest_extract_java.bin", bytes);
 
     Assert.assertTrue(Files.isRegularFile(path));
     Assert.assertArrayEquals(bytes, Files.readAllBytes(path));
@@ -58,16 +57,18 @@ public class NativeLoaderTest {
   @Test
   public void extractToCacheIsContentAddressed() throws IOException {
     byte[] bytes = "idempotent-java".getBytes("UTF-8");
-    Path first = LOADER.extractToCache("libidem_java.bin", bytes);
-    Path second = LOADER.extractToCache("libidem_java.bin", bytes);
+    Path first = NativeLoader$.MODULE$.extractToCache("libidem_java.bin", bytes);
+    Path second = NativeLoader$.MODULE$.extractToCache("libidem_java.bin", bytes);
 
     Assert.assertEquals(first, second);
   }
 
   @Test
   public void extractToCacheSeparatesDifferingContent() throws IOException {
-    Path a = LOADER.extractToCache("libdiff_java.bin", "content-A".getBytes("UTF-8"));
-    Path b = LOADER.extractToCache("libdiff_java.bin", "content-B".getBytes("UTF-8"));
+    Path a =
+        NativeLoader$.MODULE$.extractToCache("libdiff_java.bin", "content-A".getBytes("UTF-8"));
+    Path b =
+        NativeLoader$.MODULE$.extractToCache("libdiff_java.bin", "content-B".getBytes("UTF-8"));
 
     Assert.assertNotEquals(a, b);
     Assert.assertNotEquals(a.getParent(), b.getParent());
@@ -76,14 +77,15 @@ public class NativeLoaderTest {
   @Test
   public void loadIsIdempotentOnceLoaded() {
     Assert.assertNotNull(Polars.version());
-    LOADER.load("scala_polars"); // must not throw
+    NativeLoader$.MODULE$.load("scala_polars"); // must not throw
   }
 
   @Test
   public void loadingNonExistentLibraryThrowsDescriptively() {
     IllegalStateException ex =
         Assert.assertThrows(
-            IllegalStateException.class, () -> LOADER.load("scala_polars_does_not_exist"));
+            IllegalStateException.class,
+            () -> NativeLoader$.MODULE$.load("scala_polars_does_not_exist"));
     Assert.assertTrue(ex.getMessage().contains("scala_polars_does_not_exist"));
   }
 }

--- a/justfile
+++ b/justfile
@@ -34,17 +34,21 @@ fmt:
 lint:
     @just echo-command 'Checking core module'
     @sbt --batch -error scalafmtCheckAll scalafmtSbtCheck javafmtCheckAll
-    @just echo-command 'Checking test-source docs (Test/doc; caught by ci-release)'
-    @sbt --batch -error "scala-polars/Test/doc"
     @just echo-command 'Checking native module'
     @cargo clippy -q {{ cargo_flags }} --no-deps --manifest-path {{ native_manifest }} -- -D warnings
     @cargo sort {{ native_root }} --check
     @cargo fmt --check --manifest-path {{ native_manifest }}
     @just --fmt --unstable --check
 
+# Check API doc generation across all Scala versions (skip-guarded; mirrors ci-release's doc)
+[group('lint')]
+check-docs:
+    @just echo-command 'Checking API docs (Compile + Test) across Scala versions'
+    @SKIP_NATIVE_GENERATION=true sbt --batch -error "+scala-polars/Compile/doc" "+scala-polars/Test/doc"
+
 # Run all code formatting and quality checks
 [group('lint')]
-pre-commit: fmt lint
+pre-commit: fmt lint check-docs
 
 # Generate JNI headers
 [group('dev')]

--- a/justfile
+++ b/justfile
@@ -34,6 +34,8 @@ fmt:
 lint:
     @just echo-command 'Checking core module'
     @sbt --batch -error scalafmtCheckAll scalafmtSbtCheck javafmtCheckAll
+    @just echo-command 'Checking test-source docs (Test/doc; caught by ci-release)'
+    @sbt --batch -error "scala-polars/Test/doc"
     @just echo-command 'Checking native module'
     @cargo clippy -q {{ cargo_flags }} --no-deps --manifest-path {{ native_manifest }} -- -D warnings
     @cargo sort {{ native_root }} --check


### PR DESCRIPTION
## Summary

Fixes the post-merge `Publish Artifacts` failure from #309, and hardens the doc checks so it can't recur.

### The failure
`sbt ci-release` runs `Test / doc`, which the PR checks and `just site` (both `Compile / doc` only) never exercised. `NativeLoaderTest` referenced the Scala companion `NativeLoader$` in ways doc-gen can't handle:
- as a typed field (`NativeLoader$ LOADER = …`) → Scala-2.12: `not found: type NativeLoader$`
- in a `{@code NativeLoader$.MODULE$}` doc comment → Scaladoc: `Illegal group reference` (the `$.` reads as a regex group ref)

Builds and all JDK {8,25} tests passed; only the publish-only doc pass broke, so no artifact shipped.

### Fix
- Call the companion inline as `NativeLoader$.MODULE$.method(...)` in method bodies only — never in a signature or doc comment (matching `DataTypeTest`'s `Int16Type$.MODULE$`).
- Add `just check-docs`: `+scala-polars/{Compile,Test}/doc` across all Scala versions (2.12/2.13/3.3), `SKIP_NATIVE_GENERATION`-guarded so it never triggers a cargo build. Wired into `pr-lint`. The break was 2.12-specific, so cross-version coverage is required to catch it.

### Validation
- `sbt scala-polars/Test/doc` and `just check-docs` (all 3 Scala versions) pass; no native build triggered.
- Regression-proven: reintroducing the `$` doc comment fails `check-docs`; the fix passes.
- Full suite 68/68 green; `actionlint` clean on `pr-lint.yml`.
