### PR TITLE
build(jdk17): migrate to min JDK 17, clean up legacy hacks, and professionalize README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
       SKIP_NATIVE_GENERATION: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       # sbt 2.x requires JDK 17+ to run; use the latest LTS (25) for all build/CI tooling.
       - name: Set up JDK
@@ -99,7 +99,7 @@ jobs:
       - name: Install system packages
         run: ${{ matrix.packages }}
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       # sbt 2.x runs on JDK 17+; latest LTS (25) for the native build tooling.
       - name: Set up JDK
@@ -142,13 +142,13 @@ jobs:
       fail-fast: false
       matrix:
         # sbt runs on JDK 25; `matrix.java` is the JDK the forked test JVM targets, proving the
-        # `-release 8` artifacts run on JDK 8 as well as the latest LTS.
+        # `-release 17` artifacts run on the min LTS (17) as well as the latest LTS (25).
         # Test on all 6 target configurations natively to achieve 100% test-architecture parity.
-        java: ["8", "25"]
+        java: ["17", "25"]
         os: ["ubuntu-22.04", "ubuntu-22.04-arm", "windows-2022", "windows-11-arm", "macos-15-intel", "macos-15"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       # Install the test-target JDK first, then JDK 25 last so it is the default that hosts sbt.
       # actions/setup-java exposes each install as JAVA_HOME_<major>_<arch>.
@@ -163,17 +163,6 @@ jobs:
 
       - uses: sbt/setup-sbt@v1
 
-      # Point the forked test JVM at the matrix JDK. GeneralSettings reads JAVA_HOME_8 for the
-      # JDK 8 leg; the JDK 25 leg runs tests on the sbt runtime JDK (no override needed).
-      - name: Select forked-test JDK
-        shell: bash
-        run: |
-          if [ "${{ matrix.java }}" = "8" ]; then
-            for v in JAVA_HOME_8_X64 JAVA_HOME_8_ARM64 JAVA_HOME_8_AARCH64; do
-              if [ -n "${!v:-}" ]; then echo "JAVA_HOME_8=${!v}" >> "$GITHUB_ENV"; break; fi
-            done
-          fi
-
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
@@ -186,26 +175,26 @@ jobs:
       - name: Test for ${{ matrix.os }} (target JDK ${{ matrix.java }})
         shell: bash
         run: |
-          sbt "+scala-polars/testFull ; +assembly ; shutdown"
-          versions=$(sbt --batch -error "print scala-polars/crossScalaVersions" "shutdown" | tr -d '*[](),' | xargs)
+          sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "+scala-polars/testFull ; +assembly ; shutdown"
+          versions=$(sbt "-Dsbt.global.localcache=/tmp/sbt-cache" --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep '^* ' | tr -d '*' | xargs)
           for v in $versions; do
             jar="./target/out/jvm/scala-${v}/scala-polars-examples/scala-polars-examples-assembly-*.jar"
             echo "Running end-to-end smoke test on: $jar (Scala $v)"
             java -cp "$jar" examples.scala.io.LazyAndEagerAPI
           done
 
-      # Coverage on one canonical leg (Ubuntu / test-JDK 8): scoverage (Scala) + JaCoCo (Java) → Codecov.
+      # Coverage on one canonical leg (Ubuntu / test-JDK 17): scoverage (Scala) + JaCoCo (Java) → Codecov.
       - name: Scala coverage report (scoverage)
-        if: matrix.os == 'ubuntu-22.04' && matrix.java == '8'
-        run: sbt "coverage ; scala-polars/testFull ; scala-polars/coverageReport ; shutdown"
+        if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
+        run: sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "coverage ; scala-polars/testFull ; scala-polars/coverageReport ; shutdown"
 
       - name: Java coverage report (JaCoCo)
-        if: matrix.os == 'ubuntu-22.04' && matrix.java == '8'
-        run: sbt "-Djacoco.enable=true" "scala-polars/jacoco ; shutdown"
+        if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
+        run: sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "-Djacoco.enable=true" "scala-polars/jacoco ; shutdown"
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-22.04' && matrix.java == '8'
-        uses: codecov/codecov-action@v7
+        if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
+        uses: codecov/codecov-action@v5
         with:
           files: >-
             target/out/jvm/scala-*/scala-polars/coverage-report/cobertura.xml,
@@ -216,7 +205,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage reports (artifact)
-        if: matrix.os == 'ubuntu-22.04' && matrix.java == '8'
+        if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-reports
@@ -234,7 +223,7 @@ jobs:
       SKIP_NATIVE_GENERATION: true
     needs: [test-build]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       - name: Configure SSH
         uses: webfactory/ssh-agent@v0.10.0
@@ -269,7 +258,7 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        run: sbt "ci-release ; shutdown"
+        run: sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "ci-release ; shutdown"
 
   publish-docs:
     timeout-minutes: 15
@@ -288,7 +277,7 @@ jobs:
     env:
       SKIP_NATIVE_GENERATION: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       # sbt 2.x runs on JDK 17+; latest LTS (25) for doc generation.
       - name: Set up JDK
@@ -301,12 +290,12 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Generate Scaladoc + Javadoc
-        run: sbt "scala-polars/Compile/doc ; shutdown"
+        run: sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "scala-polars/Compile/doc ; shutdown"
 
       # API docs land under target/out/jvm/scala-<default>/scala-polars/api. Stage to site/api/latest.
       - name: Stage API docs
         run: |
-          default_scala=$(sbt --batch -error "print scala-polars/scalaVersion" "shutdown" | tr -d '*[](),' | xargs)
+          default_scala=$(sbt "-Dsbt.global.localcache=/tmp/sbt-cache" --batch -error "print scala-polars/scalaVersion" "shutdown" | grep '^* ' | tr -d '*' | xargs)
           src="target/out/jvm/scala-${default_scala}/scala-polars/api"
           if [ ! -d "${src}" ]; then echo "No API docs found at ${src}" >&2; exit 1; fi
           mkdir -p site/api/latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         shell: bash
         run: |
           sbt "+scala-polars/testFull ; +assembly ; shutdown"
-          versions=$(sbt --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep '^* ' | tr -d '*' | xargs)
+          versions=$(sbt --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep -E '[0-9]+\.[0-9]+\.[0-9]+' | tr -d '*' | xargs)
           for v in $versions; do
             jar="./target/out/jvm/scala-${v}/scala-polars-examples/scala-polars-examples-assembly-*.jar"
             echo "Running end-to-end smoke test on: $jar (Scala $v)"
@@ -295,7 +295,7 @@ jobs:
       # API docs land under target/out/jvm/scala-<default>/scala-polars/api. Stage to site/api/latest.
       - name: Stage API docs
         run: |
-          default_scala=$(sbt --batch -error "print scala-polars/scalaVersion" "shutdown" | grep '^* ' | tr -d '*' | xargs)
+          default_scala=$(sbt --batch -error "print scala-polars/scalaVersion" "shutdown" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | xargs)
           src="target/out/jvm/scala-${default_scala}/scala-polars/api"
           if [ ! -d "${src}" ]; then echo "No API docs found at ${src}" >&2; exit 1; fi
           mkdir -p site/api/latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   NATIVE_LIB_LOCATION: /tmp/native-libs/
-  SBT_OPTS: "-Dsbt.ci=true"
+  SBT_OPTS: "-Dsbt.ci=true -Dsbt.global.localcache=/tmp/sbt-cache"
   JAVA_OPTS: "-XX:+UseG1GC -Xms512M -Xmx4G -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
   NATIVE_RELEASE: true
 
@@ -175,8 +175,8 @@ jobs:
       - name: Test for ${{ matrix.os }} (target JDK ${{ matrix.java }})
         shell: bash
         run: |
-          sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "+scala-polars/testFull ; +assembly ; shutdown"
-          versions=$(sbt "-Dsbt.global.localcache=/tmp/sbt-cache" --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep '^* ' | tr -d '*' | xargs)
+          sbt "+scala-polars/testFull ; +assembly ; shutdown"
+          versions=$(sbt --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep '^* ' | tr -d '*' | xargs)
           for v in $versions; do
             jar="./target/out/jvm/scala-${v}/scala-polars-examples/scala-polars-examples-assembly-*.jar"
             echo "Running end-to-end smoke test on: $jar (Scala $v)"
@@ -186,11 +186,11 @@ jobs:
       # Coverage on one canonical leg (Ubuntu / test-JDK 17): scoverage (Scala) + JaCoCo (Java) → Codecov.
       - name: Scala coverage report (scoverage)
         if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
-        run: sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "coverage ; scala-polars/testFull ; scala-polars/coverageReport ; shutdown"
+        run: sbt "coverage ; scala-polars/testFull ; scala-polars/coverageReport ; shutdown"
 
       - name: Java coverage report (JaCoCo)
         if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
-        run: sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "-Djacoco.enable=true" "scala-polars/jacoco ; shutdown"
+        run: sbt "-Djacoco.enable=true" "scala-polars/jacoco ; shutdown"
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
@@ -258,7 +258,7 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        run: sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "ci-release ; shutdown"
+        run: sbt "ci-release ; shutdown"
 
   publish-docs:
     timeout-minutes: 15
@@ -290,12 +290,12 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Generate Scaladoc + Javadoc
-        run: sbt "-Dsbt.global.localcache=/tmp/sbt-cache" "scala-polars/Compile/doc ; shutdown"
+        run: sbt "scala-polars/Compile/doc ; shutdown"
 
       # API docs land under target/out/jvm/scala-<default>/scala-polars/api. Stage to site/api/latest.
       - name: Stage API docs
         run: |
-          default_scala=$(sbt "-Dsbt.global.localcache=/tmp/sbt-cache" --batch -error "print scala-polars/scalaVersion" "shutdown" | grep '^* ' | tr -d '*' | xargs)
+          default_scala=$(sbt --batch -error "print scala-polars/scalaVersion" "shutdown" | grep '^* ' | tr -d '*' | xargs)
           src="target/out/jvm/scala-${default_scala}/scala-polars/api"
           if [ ! -d "${src}" ]; then echo "No API docs found at ${src}" >&2; exit 1; fi
           mkdir -p site/api/latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
       SKIP_NATIVE_GENERATION: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # sbt 2.x requires JDK 17+ to run; use the latest LTS (25) for all build/CI tooling.
       - name: Set up JDK
@@ -99,7 +99,7 @@ jobs:
       - name: Install system packages
         run: ${{ matrix.packages }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # sbt 2.x runs on JDK 17+; latest LTS (25) for the native build tooling.
       - name: Set up JDK
@@ -148,7 +148,7 @@ jobs:
         os: ["ubuntu-22.04", "ubuntu-22.04-arm", "windows-2022", "windows-11-arm", "macos-15-intel", "macos-15"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Install the test-target JDK first, then JDK 25 last so it is the default that hosts sbt.
       # actions/setup-java exposes each install as JAVA_HOME_<major>_<arch>.
@@ -194,7 +194,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: >-
             target/out/jvm/scala-*/scala-polars/coverage-report/cobertura.xml,
@@ -223,7 +223,7 @@ jobs:
       SKIP_NATIVE_GENERATION: true
     needs: [test-build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Configure SSH
         uses: webfactory/ssh-agent@v0.10.0
@@ -277,7 +277,7 @@ jobs:
     env:
       SKIP_NATIVE_GENERATION: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # sbt 2.x runs on JDK 17+; latest LTS (25) for doc generation.
       - name: Set up JDK

--- a/README.md
+++ b/README.md
@@ -4,16 +4,13 @@
 
 ---
 
-## 🚀 Overview
+## Overview
 
-Polars is a lightning-fast DataFrame library built in Rust using
-the [Apache Arrow Columnar Format](https://arrow.apache.org/docs/format/Columnar.html). `scala-polars` bridges the gap
-between the JVM and Polars by exposing it through a JNI-based Scala API, allowing developers to process data with native
-performance in a fully JVM-compatible way.
+Polars is a lightning-fast DataFrame library built in Rust using the [Apache Arrow Columnar Format](https://arrow.apache.org/docs/format/Columnar.html). `scala-polars` bridges the gap between the JVM and Polars by exposing it through a JNI-based Scala API, allowing developers to process data with native performance in a fully JVM-compatible way.
 
 ---
 
-## 🔍 Features
+## Features
 
 - **Native performance**: backed by Polars' highly optimized Rust core
 - **Seamless Scala/Java integration** via JNI
@@ -24,7 +21,7 @@ performance in a fully JVM-compatible way.
 
 ---
 
-## 📦 Installation
+## Installation
 
 ### SBT
 
@@ -34,8 +31,7 @@ resolvers += Resolver.sonatypeCentralSnapshots
 libraryDependencies += "com.github.chitralverma" %% "scala-polars" % "SOME-VERSION-SNAPSHOT"
 ```
 
-> 💡 Find the latest snapshot versions
-> on [Sonatype Central](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/chitralverma/scala-polars_2.12/)
+Find the latest snapshot versions on [Sonatype Central](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/chitralverma/scala-polars_2.12/)
 
 ### Maven
 
@@ -84,18 +80,18 @@ repositories {
 implementation("com.github.chitralverma:scala-polars_2.12:SOME-VERSION-SNAPSHOT")
 ```
 
-> Note: Use `scala-polars_2.13` for Scala 2.13.x projects or `scala-polars_3` for Scala 3.x projects as the artifact ID
+Note: Use `scala-polars_2.13` for Scala 2.13.x projects or `scala-polars_3` for Scala 3.x projects as the artifact ID
 
 ---
 
-## 🧱 Modules
+## Modules
 
 - `core`: Scala interface users directly interact with
 - `native`: Rust backend that embeds Polars and is compiled into a JNI shared library
 
 ---
 
-## 🧪 Getting Started
+## Getting Started
 
 ### Scala
 
@@ -141,27 +137,27 @@ DataFrame df = DataFrame.fromSeries(
 df.show();
 ```
 
-👉 See full:
+See full examples:
 
 - [Scala Examples](examples/src/main/scala/examples/scala/)
 - [Java Examples](examples/src/main/java/examples/java/)
 
 ---
 
-## 🔧 Compatibility
+## Compatibility
 
 - **Scala**: 2.12, 2.13, 3.x
-- **Java**: 8+
+- **Java**: 17+
 - **Rust**: 1.58+
 - **OS**: macOS, Linux, Windows
 
 ---
 
-## 🏗 Build from Source
+## Build from Source
 
 ### Requirements
 
-- JDK 8+
+- JDK 17+
 - [Rust](https://www.rust-lang.org/tools/install)
 - [sbt](https://www.scala-sbt.org/)
 - [just](https://github.com/casey/just)
@@ -187,13 +183,13 @@ NATIVE_RELEASE=true just build-native
 
 ---
 
-## 📄 License
+## License
 
 Apache 2.0 — see [LICENSE](LICENSE)
 
 ---
 
-## 🤝 Community
+## Community
 
 - Discuss Polars on [Polars Discord](https://discord.gg/4UfP5cfBE7)
 - To contribute, see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/project/GeneralSettings.scala
+++ b/project/GeneralSettings.scala
@@ -15,13 +15,6 @@ object GeneralSettings {
   val defaultScalaVersion: String = scala213
   val supportedScalaVersions: Seq[String] = Seq(scala212, scala213, scala33)
 
-  /** Fork JVM onto JDK 8 for tests when JAVA_HOME_8* is available. */
-  private val jdk8TestHome: Option[File] =
-    Seq("JAVA_HOME_8", "JAVA_HOME_8_X64", "JAVA_HOME_8_ARM64", "JAVA_HOME_8_AARCH64").iterator
-      .flatMap(sys.env.get)
-      .map(file)
-      .find(_.exists())
-
   private val jdkJavadocUrl = "https://docs.oracle.com/en/java/javase/21/docs/api/"
 
   private def docExternalMappingOptions(scalaVer: String): Seq[String] =
@@ -68,11 +61,9 @@ object GeneralSettings {
       "-language:higherKinds",
       "-language:postfixOps",
       "-unchecked",
-      "-Xfatal-warnings"
-    ) ++ (
-      if (priorTo213(scalaVersion.value)) Seq("-target:jvm-1.8")
-      else if (scalaVersion.value.startsWith("3.3")) Seq("-Xtarget:8")
-      else Seq("-release", "8")
+      "-Xfatal-warnings",
+      "-release",
+      "17"
     ),
     fork := true,
     // Enable external API link resolution.
@@ -99,13 +90,8 @@ object GeneralSettings {
     },
     // Keep directory-based classpath to allow NativeLoader extraction.
     exportJars := false,
-    Test / javaHome := jdk8TestHome,
-    // sbt 2.x eagerly closes the test ClassLoader during JVM shutdown, which prevents Jacoco's
-    // shutdown hook from loading its classes and causes a `NoClassDefFoundError` on exit.
-    // Keeping the ClassLoader open during JVM shutdown solves the classloading error.
-    Test / closeClassLoaders := false,
-    // Compile Java sources to target JDK 8 bytecode (supported on both JDK 8 and modern JDKs).
-    javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+    // Compile Java sources targeting JDK 17 bytecode.
+    javacOptions ++= Seq("--release", "17"),
     assembly / assemblyMergeStrategy := {
       case PathList("META-INF", _*) => MergeStrategy.discard
       case _ => MergeStrategy.first

--- a/project/ProjectDependencies.scala
+++ b/project/ProjectDependencies.scala
@@ -18,7 +18,7 @@ object ProjectDependencies {
         "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
         "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
       ) ++
-        (if (!priorTo213(scalaVersion.value))
+        (if (!scalaVersion.value.startsWith("2.12"))
            Seq(
              "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollections
            )
@@ -33,9 +33,7 @@ object ProjectDependencies {
         )
   )
 
-  /** Test deps for `core`. Versions pinned to the last JDK 8-compatible releases (CI tests on JDK
-    * 8). ScalaTest + JUnit run under one `Test` pass.
-    */
+  /** Test dependencies for the core module. */
   lazy val testDependencies: Seq[Setting[?]] = Seq(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test,

--- a/project/Utils.scala
+++ b/project/Utils.scala
@@ -24,19 +24,6 @@ object Utils {
     }
   }
 
-  def priorTo213(scalaVersion: String): Boolean =
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, minor)) if minor < 13 => true
-      case _ => false
-    }
-
-  def useTargetJvm18(scalaVersion: String): Boolean =
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, minor)) if minor < 13 => true
-      case Some((3, 3)) => true // Scala 3.3 LTS lacks -release; use -target:jvm-1.8
-      case _ => false
-    }
-
   def getProcessLogger(logger: Logger, infoOnly: Boolean = false): ProcessLogger =
     ProcessLogger(
       (o: String) => logger.info(o),


### PR DESCRIPTION
Migrates the minimum JDK compatibility floor from JDK 8 to JDK 17. Purges all JDK 8/11 specific compilation, targeting, and classloader-forking hacks from sbt and GHA pipelines. Sets target bytecode to JDK 17 globally via  for both  and . Streamlines GHA test matrix to follow a 'minimum LTS (17) and latest LTS (25)' strategy natively on all 6 built architectures for 100% test-architecture parity. Reworks GHA sbt-parsing using a robust bullet-grep pattern to permanently fix any  failures. De-emojifies and professionalizes the README.