### PR TITLE
ci: restrict sbt-extracted versions to crossScalaVersions pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         shell: bash
         run: |
           sbt "+scala-polars/testFull ; +assembly ; shutdown"
-          versions=$(sbt --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep -E '[0-9]+\.[0-9]+\.[0-9]+' | tr -d '*' | xargs)
+          versions=$(sbt --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep -E '(2\.12\.|2\.13\.|3\.3\.)' | tr -d '*' | xargs)
           for v in $versions; do
             jar="./target/out/jvm/scala-${v}/scala-polars-examples/scala-polars-examples-assembly-*.jar"
             echo "Running end-to-end smoke test on: $jar (Scala $v)"
@@ -295,7 +295,7 @@ jobs:
       # API docs land under target/out/jvm/scala-<default>/scala-polars/api. Stage to site/api/latest.
       - name: Stage API docs
         run: |
-          default_scala=$(sbt --batch -error "print scala-polars/scalaVersion" "shutdown" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | xargs)
+          default_scala=$(sbt --batch -error "print scala-polars/scalaVersion" "shutdown" | grep -E '(2\.12\.|2\.13\.|3\.3\.)' | xargs)
           src="target/out/jvm/scala-${default_scala}/scala-polars/api"
           if [ ! -d "${src}" ]; then echo "No API docs found at ${src}" >&2; exit 1; fi
           mkdir -p site/api/latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         shell: bash
         run: |
           sbt "+scala-polars/testFull ; +assembly ; shutdown"
-          versions=$(sbt --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep -E '(2\.12\.|2\.13\.|3\.3\.)' | tr -d '*' | xargs)
+          versions=$(sbt --batch -error "print scala-polars/crossScalaVersions" "shutdown" | grep -Eo '(2\.12|2\.13|3\.3)\.[0-9]+' | xargs)
           for v in $versions; do
             jar="./target/out/jvm/scala-${v}/scala-polars-examples/scala-polars-examples-assembly-*.jar"
             echo "Running end-to-end smoke test on: $jar (Scala $v)"
@@ -295,7 +295,7 @@ jobs:
       # API docs land under target/out/jvm/scala-<default>/scala-polars/api. Stage to site/api/latest.
       - name: Stage API docs
         run: |
-          default_scala=$(sbt --batch -error "print scala-polars/scalaVersion" "shutdown" | grep -E '(2\.12\.|2\.13\.|3\.3\.)' | xargs)
+          default_scala=$(sbt --batch -error "print scala-polars/scalaVersion" "shutdown" | grep -Eo '(2\.12|2\.13|3\.3)\.[0-9]+' | head -n 1 | xargs)
           src="target/out/jvm/scala-${default_scala}/scala-polars/api"
           if [ ! -d "${src}" ]; then echo "No API docs found at ${src}" >&2; exit 1; fi
           mkdir -p site/api/latest


### PR DESCRIPTION
Permanently fixes the GHA release pipeline failures.
During the second sbt call inside the test and doc-publishing steps (which runs `sbt "print scala-polars/crossScalaVersions"` and `sbt "print scala-polars/scalaVersion"`), the background sbt server has been shut down. Thus, sbt launches a brand new server instance, printing a startup welcome message: `welcome to sbt 2.0.1 (Azul Systems, Inc. Java 25.0.3)`.

Since the previous generic semver regex (`[0-9]+\.[0-9]+\.[0-9]+`) matched any 3-digit dot-separated version, it accidentally captured `2.0.1` and `25.0.3` from the welcome message and appended them to the `versions` list. The subsequent loop then crashed because there are no Scala `2.0.1` or `25.0.3` compiled directories.

This fix restricts the version-grep pattern to specifically match the valid cross-compiled Scala versions (`2.12.`, `2.13.`, or `3.3.`). This robustly filters out the sbt startup/JVM welcome headers and ensures only the correct, expected Scala target versions are extracted.