### PR TITLE
ci: fix sbt 2.x jacoco desync and forked JVM shutdown crash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,9 @@ jobs:
 
       - name: Java coverage report (JaCoCo)
         if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'
-        run: sbt "scala-polars/jacoco"
+        env:
+          RUN_COVERAGE: "true"
+        run: sbt "reload ; scala-polars/jacoco"
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-22.04' && matrix.java == '17'

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,8 @@
 import Utils.*
 
+val enableCoverage =
+  sys.env.get("RUN_COVERAGE").contains("true") || sys.props.get("jacoco.enable").contains("true")
+
 /*
  ***********************
  * Root (aggregate) *
@@ -28,7 +31,10 @@ lazy val core = project
   .in(file("core"))
   .withId("scala-polars")
   .settings(name := "scala-polars")
-  .enablePlugins(JacocoPlugin)
+  .configure { p =>
+    if (enableCoverage) p.enablePlugins(JacocoPlugin)
+    else p.disablePlugins(JacocoPlugin)
+  }
   .settings(ProjectDependencies.dependencies)
   .settings(ProjectDependencies.testDependencies)
   .settings(ProjectDependencies.coverageSettings)
@@ -55,6 +61,10 @@ lazy val examples = project
   .withId("scala-polars-examples")
   .settings(name := "scala-polars-examples")
   .settings(GeneralSettings.commonSettings)
+  .configure { p =>
+    if (enableCoverage) p.enablePlugins(JacocoPlugin)
+    else p.disablePlugins(JacocoPlugin)
+  }
   .settings(
     publish / skip := true,
     publishArtifact := false


### PR DESCRIPTION
Permanently fixes the GHA test leg and Jacoco failures.
1. Restores the conditional enabling of `JacocoPlugin` inside `build.sbt` only when coverage is requested. This is absolutely critical because when Jacoco is always enabled, every single cross-built test suite execution (including the main `testFull` leg) runs under Jacoco offline instrumentation, which triggers a background JVM thread crash on JVM exit with `NoClassDefFoundError: ExecutionDataWriter` (due to sbt 2.x forked test ClassLoader closing dynamics). Keeping Jacoco disabled during standard tests keeps them perfectly clean and stable.
2. Fixes the `Not a valid key: jacoco` sbt 2.x server desync by invoking `sbt "reload ; scala-polars/jacoco"` in the GHA JaCoCo step. This forces sbt's persistent background server to reload the build definitions on demand, safely evaluating the GHA step-level `RUN_COVERAGE: true` environment variable and dynamically enabling Jacoco and its task only when required.