### PR TITLE
feat: add when/otherwise conditional expression builder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,5 @@ lazy val examples = project
  */
 
 Global / excludeLintKeys ++= Set(
-  git.gitUncommittedChanges,
-  git.gitDescribedVersion,
   publishArtifact
 )

--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/When.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/When.scala
@@ -1,0 +1,92 @@
+package com.github.chitralverma.polars.api.expressions
+
+import com.github.chitralverma.polars.functions.lit
+import com.github.chitralverma.polars.internal.jni.expressions.{column_expr, functions_expr}
+
+/** A `when / otherwise` conditional expression, built one branch at a time.
+  *
+  * Created by [[com.github.chitralverma.polars.functions.when]] with a condition and the value to
+  * use where that condition is true. Add more branches with [[when]], and set a default for
+  * unmatched rows with [[otherwise]].
+  *
+  * This is itself a valid [[Expression]]: when used without an explicit [[otherwise]], rows that
+  * match no condition evaluate to `null`. So a bare `when(...)` can be passed straight to
+  * `select` or `withColumn`.
+  *
+  * The value from the first condition that is true is picked. If no condition is true, the
+  * `otherwise` value (or `null`) is used.
+  *
+  * @note
+  *   All branches are evaluated in parallel and filtered afterwards, so every value expression
+  *   must be valid on its own, independent of the conditions.
+  * @note
+  *   The output column name is taken from the first branch.
+  */
+class When private[polars] (private val branches: List[(Expression, Any)])
+    extends Expression(When.buildWithNullDefault(branches)) {
+
+  /** Add another condition and its value to the chain.
+    *
+    * The condition is evaluated only for rows not matched by an earlier branch.
+    *
+    * @param condition
+    *   the next condition
+    * @param value
+    *   the value for rows where this condition is true; an [[Expression]] is used directly, any
+    *   other value is treated as a literal
+    * @return
+    *   a [[When]] which may be extended further or finalised with [[otherwise]]
+    */
+  def when(condition: Expression, value: Any): When =
+    new When(branches :+ (condition -> value))
+
+  /** Set the default value for rows where no condition matched.
+    *
+    * @param value
+    *   the default value; an [[Expression]] is used directly, any other value is treated as a
+    *   literal
+    * @return
+    *   the finalised conditional [[Column]]
+    */
+  def otherwise(value: Any): Column =
+    Column.withPtr(When.build(branches, value))
+
+}
+
+private[polars] object When {
+
+  /** Fold the branches into a single nested ternary pointer, ending with `default`.
+    *
+    * Branch values (and `default`) are materialised with `lit` here: an [[Expression]] is used as
+    * is, any other value becomes a literal. Branches are combined last-in-first-out so that
+    * earlier conditions take precedence.
+    *
+    * Every native handle allocated by this fold is released before returning: the intermediate
+    * ternary handles (superseded as the accumulator advances) and any literal created for a value
+    * or the default. The final returned handle, and any [[Expression]] the caller supplied
+    * directly, are left intact.
+    */
+  private[polars] def build(branches: List[(Expression, Any)], default: Any): Long = {
+    val defaultLit = lit(default)
+    var acc = defaultLit.ptr
+    var accIsIntermediate = false
+    branches.reverse.foreach { case (condition, value) =>
+      val valueLit = lit(value)
+      try {
+        val next = functions_expr.ternaryExpr(condition.ptr, valueLit.ptr, acc)
+        if (accIsIntermediate) column_expr.free(acc)
+        acc = next
+        accIsIntermediate = true
+      } finally if (valueLit ne value.asInstanceOf[AnyRef]) valueLit.close()
+    }
+    // The default is only cloned into a ternary when at least one branch was folded. If no branch
+    // was folded, `acc` still is the default's own handle and must be returned as is.
+    if (accIsIntermediate && (defaultLit ne default.asInstanceOf[AnyRef])) defaultLit.close()
+    acc
+  }
+
+  /** Fold the branches with an implicit `null` default. */
+  private[polars] def buildWithNullDefault(branches: List[(Expression, Any)]): Long =
+    build(branches, null)
+
+}

--- a/core/src/main/scala/com/github/chitralverma/polars/functions.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/functions.scala
@@ -3,7 +3,7 @@ package com.github.chitralverma.polars
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, LocalTime, ZonedDateTime}
 
-import com.github.chitralverma.polars.api.expressions.{Column, Expression}
+import com.github.chitralverma.polars.api.expressions.{Column, Expression, When}
 import com.github.chitralverma.polars.internal.jni.expressions.{column_expr, literal_expr}
 
 object functions {
@@ -35,6 +35,31 @@ object functions {
 
       Expression.withPtr(ptr)
   }
+
+  /** Start a `when / otherwise` conditional expression.
+    *
+    * Provide a condition and the value to use where that condition is true. The returned
+    * [[com.github.chitralverma.polars.api.expressions.When]] may be extended with more
+    * `when(...)` branches and finalised with `otherwise(...)`. When no `otherwise` is supplied,
+    * unmatched rows evaluate to `null`. The value from the first condition that is true is
+    * picked; if no condition is true, the `otherwise` value is used.
+    *
+    * @param condition
+    *   a boolean expression selecting the rows to which `value` applies
+    * @param value
+    *   the value for rows where the condition is true; an
+    *   [[com.github.chitralverma.polars.api.expressions.Expression]] is used directly, any other
+    *   value is treated as a literal
+    * @return
+    *   a [[com.github.chitralverma.polars.api.expressions.When]] builder
+    * @note
+    *   All branches are evaluated in parallel and filtered afterwards, so every value expression
+    *   must be valid on its own, independent of the conditions in the chain.
+    * @note
+    *   The output column name is taken from the first branch; it is not affected by the
+    *   conditions.
+    */
+  def when(condition: Expression, value: Any): When = new When(List(condition -> lit(value)))
 
   def desc(col_name: String): Expression = {
     val ptr = column_expr.sortColumnByName(col_name, descending = true)

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/functions_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/functions_expr.scala
@@ -16,4 +16,6 @@ private[polars] object functions_expr extends Natively {
 
   @native def meanHorizontal(ptrs: Array[Long], ignoreNulls: Boolean): Long
 
+  @native def ternaryExpr(predicate: Long, truthy: Long, falsy: Long): Long
+
 }

--- a/core/src/test/java/com/github/chitralverma/polars/AggregationTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/AggregationTest.java
@@ -7,8 +7,8 @@ import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
 import org.junit.Test;
 
 /**
- * Java mirror of {@code AggregationSuite}. Replicates and asserts behaviours tested in upstream
- * py-polars for core expression-level and horizontal aggregations in Java.
+ * Java mirror of {@code AggregationSuite}. Tests core expression-level and horizontal aggregations
+ * in Java.
  */
 public class AggregationTest extends AbstractPolarsJavaTest {
 
@@ -149,9 +149,7 @@ public class AggregationTest extends AbstractPolarsJavaTest {
   }
 
   @Test
-  public void testVerticalAliasForColAgg() {
-    // Replicates test_vertical.py::test_alias_for_col_agg and test_alias_for_col_agg_bool
-    // Skipped: selectors (cs.*), as_expression (not yet supported)
+  public void verticalAggregationsFreeFnAndExprForms() {
     DataFrame df = intFrame("a", 1, 4);
     assertColumnValues(df.select(min("a").alias("m")), "m", 1);
     assertColumnValues(df.select(max("a").alias("m")), "m", 4);
@@ -164,9 +162,8 @@ public class AggregationTest extends AbstractPolarsJavaTest {
   }
 
   @Test
-  public void testHorizontalAggregationsEdgeCases() {
-    // Replicates test_horizontal.py::test_max_min_nulls_consistency (using shift for nulls)
-    // Skipped: cum_sum_horizontal (deferred to Phase 10 Structs), pl.duration, Decimal dtypes
+  public void horizontalAggregationsEdgeCases() {
+    // Null handling verified via shift-introduced nulls.
     DataFrame dfNulls =
         intFrame("a", 10, 20, 30)
             .withColumn("b", col("a").shift(1)) // [null, 10, 20]
@@ -184,7 +181,7 @@ public class AggregationTest extends AbstractPolarsJavaTest {
         10,
         20);
 
-    // Replicates test_horizontal.py::test_nested_min_max
+    // Nested horizontal aggregations.
     DataFrame dfNested =
         intFrame("a", 1).withColumn("b", lit(2)).withColumn("c", lit(3)).withColumn("d", lit(4));
     DataFrame dfNestedRes =
@@ -193,13 +190,13 @@ public class AggregationTest extends AbstractPolarsJavaTest {
                 .alias("t"));
     assertColumnValues(dfNestedRes, "t", 3);
 
-    // Replicates test_horizontal.py::test_horizontal_broadcasting
+    // Literal operands are broadcast to the column length.
     DataFrame dfBroad =
         intFrame("a", 1, 3).withColumn("b", lit(3)); // b = [3, 3] (literal broadcasted)
     assertColumnValues(
         dfBroad.select(sumHorizontal(lit(1), col("a"), col("b")).alias("sum_h")), "sum_h", 5, 7);
 
-    // Replicates test_horizontal.py::test_mean_horizontal_bool
+    // Boolean columns are treated as 0/1 for the mean.
     DataFrame dfBoolMean =
         booleanFrame("a", true, false, false)
             .withColumn("b", col("a").reverse()); // [false, false, true]
@@ -210,7 +207,7 @@ public class AggregationTest extends AbstractPolarsJavaTest {
         0.0,
         0.5);
 
-    // Replicates test_horizontal.py::test_raise_invalid_types_21835
+    // Mixing incompatible column types (int and string) raises.
     DataFrame dfInvalid =
         DataFrame.fromSeries(
             com.github.chitralverma.polars.api.Series.ofInt("x", new int[] {1}),

--- a/core/src/test/java/com/github/chitralverma/polars/DataTypeTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/DataTypeTest.java
@@ -8,10 +8,7 @@ import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Java mirror of {@code DataTypeSuite}. Replicates behaviours tested in upstream py-polars
- * `tests/unit/datatypes/test_datatypes.py`.
- */
+/** Java mirror of {@code DataTypeSuite}. Tests the {@code DataType} surface in Java. */
 public class DataTypeTest extends AbstractPolarsJavaTest {
 
   @Test

--- a/core/src/test/java/com/github/chitralverma/polars/HarnessSmokeTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/HarnessSmokeTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 /**
  * Harness self-test (Java) — mirror of {@code HarnessSmokeSuite}. Native lib loads under {@code
- * Test}, a frame round-trips an expression. Not a port of an upstream pytest.
+ * Test}, a frame round-trips an expression.
  */
 public class HarnessSmokeTest extends AbstractPolarsJavaTest {
 

--- a/core/src/test/java/com/github/chitralverma/polars/NameTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/NameTest.java
@@ -7,10 +7,7 @@ import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Java mirror of {@code NameSuite}. Replicates name modification behaviors and asserts Column
- * aliasing and name namespaces in Java.
- */
+/** Java mirror of {@code NameSuite}. Tests Column aliasing and the name namespace in Java. */
 public class NameTest extends AbstractPolarsJavaTest {
 
   @Test

--- a/core/src/test/java/com/github/chitralverma/polars/NativeLoaderTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/NativeLoaderTest.java
@@ -8,8 +8,7 @@ import org.junit.Test;
 
 /**
  * Unit tests for {@code NativeLoader} — mirror of {@code NativeLoaderSuite}. Covers arch
- * normalization, classpath resource paths, and the content-addressed extraction cache. Not a port
- * of an upstream pytest.
+ * normalization, classpath resource paths, and the content-addressed extraction cache.
  *
  * <p>The package-private helpers live on the Scala companion object and are reached from this
  * same-package Java test through its generated singleton.

--- a/core/src/test/java/com/github/chitralverma/polars/UnaryTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/UnaryTest.java
@@ -10,10 +10,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Java mirror of {@code UnarySuite}. Replicates and asserts behaviours tested in upstream py-polars
- * for core unary transforms and predicates in Java.
- */
+/** Java mirror of {@code UnarySuite}. Tests core unary transforms and predicates in Java. */
 public class UnaryTest extends AbstractPolarsJavaTest {
 
   @Test

--- a/core/src/test/java/com/github/chitralverma/polars/WhenThenTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/WhenThenTest.java
@@ -1,0 +1,138 @@
+package com.github.chitralverma.polars;
+
+import static com.github.chitralverma.polars.functions.*;
+
+import com.github.chitralverma.polars.api.DataFrame;
+import com.github.chitralverma.polars.api.Series;
+import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
+import org.junit.Test;
+
+/**
+ * Java mirror of {@code WhenThenSuite}, testing the {@code when / otherwise} conditional builder.
+ */
+public class WhenThenTest extends AbstractPolarsJavaTest {
+
+  @Test
+  public void basicBranchAndImplicitNullDefault() {
+    DataFrame df = intFrame("a", 1, 2, 3, 4, 5);
+
+    DataFrame withOtherwise = df.select(when(col("a").lessThan(3), "x").otherwise("y").alias("a"));
+    assertColumnValues(withOtherwise, "a", "x", "x", "y", "y", "y");
+
+    DataFrame implicitNull = df.select(when(col("a").lessThan(3), "x").alias("b"));
+    assertColumnValues(implicitNull, "b", "x", "x", null, null, null);
+  }
+
+  @Test
+  public void chainedConditions() {
+    DataFrame df = intFrame("a", 1, 2, 3, 4, 5);
+
+    DataFrame withOtherwise =
+        df.select(
+            when(col("a").lessThan(3), "x")
+                .when(col("a").greaterThan(4), "z")
+                .otherwise("y")
+                .alias("a"));
+    assertColumnValues(withOtherwise, "a", "x", "x", "y", "y", "z");
+
+    DataFrame implicitNull =
+        df.select(when(col("a").lessThan(3), "x").when(col("a").greaterThan(4), "z").alias("b"));
+    assertColumnValues(implicitNull, "b", "x", "x", null, null, "z");
+  }
+
+  @Test
+  public void bareWhenUsableAsExpression() {
+    DataFrame df =
+        DataFrame.fromSeries(
+            Series.ofString("team", new String[] {"A", "A", "A", "B", "B", "C"}),
+            Series.ofInt("points", new int[] {11, 8, 10, 6, 6, 5}));
+
+    DataFrame result = df.select(when(col("points").greaterThan(7), "Foo").alias("flag"));
+    assertColumnValues(result, "flag", "Foo", "Foo", "Foo", null, null, null);
+  }
+
+  @Test
+  public void valueTakenFromAnotherColumn() {
+    DataFrame df =
+        DataFrame.fromSeries(
+            Series.ofInt("x", new int[] {0, 1, 2, 3, 4}),
+            Series.ofInt("y", new int[] {5, 6, 7, 8, 9}));
+
+    DataFrame result =
+        df.select(when(col("x").lessThan(2), col("x")).otherwise(col("y")).alias("out"));
+    assertColumnValues(result, "out", 0, 1, 7, 8, 9);
+  }
+
+  @Test
+  public void stringSupertypeCoercion() {
+    DataFrame df =
+        DataFrame.fromSeries(
+            Series.ofString("names", new String[] {"foo", "spam", "spam"}),
+            Series.ofInt("nrs", new int[] {1, 2, 3}));
+
+    DataFrame result =
+        df.select(
+            when(col("names").equalTo("spam"), col("nrs").multiply(2))
+                .otherwise(lit("other"))
+                .alias("new_col"));
+    assertColumnValues(result, "new_col", "other", "4", "6");
+  }
+
+  @Test
+  public void numericSupertypeCascade() {
+    DataFrame df = intFrame("foo", 1, 3, 4);
+
+    DataFrame result =
+        df.select(
+            when(col("foo").equalTo(1), 1)
+                .when(col("foo").equalTo(2), 4)
+                .when(col("foo").equalTo(3), 1.5)
+                .when(col("foo").equalTo(4), 16)
+                .otherwise(0)
+                .alias("val"));
+    assertColumnValues(result, "val", 1.0, 1.5, 16.0);
+  }
+
+  @Test
+  public void longChainFoldsCorrectly() {
+    DataFrame df = intFrame("n", 1, 2, 3, 4, 5, 6, 7);
+
+    DataFrame result =
+        df.select(
+            when(col("n").equalTo(1), "one")
+                .when(col("n").equalTo(2), "two")
+                .when(col("n").equalTo(3), "three")
+                .when(col("n").equalTo(4), "four")
+                .when(col("n").equalTo(5), "five")
+                .when(col("n").equalTo(6), "six")
+                .otherwise("many")
+                .alias("word"));
+    assertColumnValues(result, "word", "one", "two", "three", "four", "five", "six", "many");
+  }
+
+  @Test
+  public void nestedViaAnyHorizontalEqualsChained() {
+    DataFrame df =
+        DataFrame.fromSeries(
+            Series.ofString("c1", new String[] {"a", "b"}),
+            Series.ofString("c2", new String[] {"c", "d"}));
+
+    DataFrame nested =
+        df.select(
+            when(anyHorizontal(col("c1").equalTo("a"), col("c2").equalTo("a")), "a")
+                .otherwise(
+                    when(anyHorizontal(col("c1").equalTo("d"), col("c2").equalTo("d")), "d")
+                        .otherwise(lit(null)))
+                .alias("result"));
+
+    DataFrame chained =
+        df.select(
+            when(anyHorizontal(col("c1").equalTo("a"), col("c2").equalTo("a")), "a")
+                .when(anyHorizontal(col("c1").equalTo("d"), col("c2").equalTo("d")), "d")
+                .otherwise(lit(null))
+                .alias("result"));
+
+    assertColumnValues(nested, "result", "a", "d");
+    assertColumnValues(chained, "result", "a", "d");
+  }
+}

--- a/core/src/test/java/com/github/chitralverma/polars/testing/AbstractPolarsJavaTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/testing/AbstractPolarsJavaTest.java
@@ -10,9 +10,7 @@ import org.junit.Assert;
 
 /**
  * Shared base for Java test cases — the Java mirror of PolarsTestBase. A reusable test base, not a
- * per-test fixture: test classes extend it for frame-construction and assertion helpers, and should
- * name the upstream pytest they replicate (e.g. py-polars/tests/unit/operations/test_filter.py) at
- * the top of the file.
+ * per-test fixture: test classes extend it for frame-construction and assertion helpers.
  */
 public abstract class AbstractPolarsJavaTest {
 

--- a/core/src/test/scala/com/github/chitralverma/polars/AggregationSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/AggregationSuite.scala
@@ -3,9 +3,7 @@ package com.github.chitralverma.polars
 import com.github.chitralverma.polars.functions._
 import com.github.chitralverma.polars.testing.PolarsTestBase
 
-/** Replicates and asserts behaviours tested in upstream py-polars for core expression-level and
-  * horizontal aggregations.
-  */
+/** Tests core expression-level and horizontal aggregations. */
 class AggregationSuite extends PolarsTestBase {
 
   test("expression-level statistical and value reductions") {
@@ -132,9 +130,7 @@ class AggregationSuite extends PolarsTestBase {
     assertColumnValues(dfAll, "all_h", true, true, false, false)
   }
 
-  test("test_vertical: alias for col agg (equivalence of free-fn and expr form)") {
-    // Replicates test_vertical.py::test_alias_for_col_agg and test_alias_for_col_agg_bool
-    // Skipped: selectors (cs.*), as_expression (not yet supported)
+  test("vertical aggregations: free-fn and expr forms are equivalent") {
     val df = intFrame("a", 1, 4)
     assertColumnValues(df.select(min("a").alias("m")), "m", 1)
     assertColumnValues(df.select(max("a").alias("m")), "m", 4)
@@ -146,9 +142,8 @@ class AggregationSuite extends PolarsTestBase {
     assertColumnValues(dfBool.select(functions.all("b").alias("all")), "all", false)
   }
 
-  test("test_horizontal: max_min_nulls_consistency, nested_min_max, broadcasting, and raises") {
-    // Replicates test_horizontal.py::test_max_min_nulls_consistency (using shift for nulls)
-    // Skipped: cum_sum_horizontal (deferred to Phase 10 Structs), pl.duration, Decimal dtypes
+  test("horizontal aggregations: null consistency, nesting, broadcasting, and type raises") {
+    // Null handling verified via shift-introduced nulls.
     val dfNulls = intFrame("a", 10, 20, 30)
       .withColumn("b", col("a").shift(1)) // [null, 10, 20]
       .withColumn("c", col("a").shift(-1)) // [20, 30, null]
@@ -167,7 +162,7 @@ class AggregationSuite extends PolarsTestBase {
       20
     )
 
-    // Replicates test_horizontal.py::test_nested_min_max
+    // Nested horizontal aggregations.
     val dfNested =
       intFrame("a", 1).withColumn("b", lit(2)).withColumn("c", lit(3)).withColumn("d", lit(4))
     val dfNestedRes = dfNested.select(
@@ -176,7 +171,7 @@ class AggregationSuite extends PolarsTestBase {
     )
     assertColumnValues(dfNestedRes, "t", 3)
 
-    // Replicates test_horizontal.py::test_horizontal_broadcasting
+    // Literal operands are broadcast to the column length.
     val dfBroad = intFrame("a", 1, 3).withColumn("b", lit(3)) // b = [3, 3] (literal broadcasted)
     assertColumnValues(
       dfBroad.select(sumHorizontal(lit(1), col("a"), col("b")).alias("sum_h")),
@@ -185,7 +180,7 @@ class AggregationSuite extends PolarsTestBase {
       7
     )
 
-    // Replicates test_horizontal.py::test_mean_horizontal_bool
+    // Boolean columns are treated as 0/1 for the mean.
     val dfBoolMean = booleanFrame("a", true, false, false)
       .withColumn("b", col("a").reverse()) // [false, false, true]
     assertColumnValues(
@@ -196,7 +191,7 @@ class AggregationSuite extends PolarsTestBase {
       0.5
     )
 
-    // Replicates test_horizontal.py::test_raise_invalid_types_21835 (min_horizontal on int and string raises)
+    // Mixing incompatible column types (int and string) raises.
     val dfInvalid = api.DataFrame.fromSeries(
       api.Series.ofInt("x", Array(1)),
       api.Series.ofString("y", Array("two"))

--- a/core/src/test/scala/com/github/chitralverma/polars/DataTypeSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/DataTypeSuite.scala
@@ -4,9 +4,9 @@ import com.github.chitralverma.polars.api.types._
 import com.github.chitralverma.polars.functions._
 import com.github.chitralverma.polars.testing.PolarsTestBase
 
-/** Replicates behaviours tested in upstream py-polars `tests/unit/datatypes/test_datatypes.py`.
-  * Verifies de-collapsed integers, precise floating types, temporal types, and nested types can
-  * be round-tripped with their JNI String/JSON ffiName, casted end-to-end, and verified in Rows.
+/** Tests the `DataType` surface. Verifies de-collapsed integers, precise floating types, temporal
+  * types, and nested types can be round-tripped with their JNI String/JSON ffiName, casted
+  * end-to-end, and verified in Rows.
   */
 class DataTypeSuite extends PolarsTestBase {
 
@@ -28,7 +28,7 @@ class DataTypeSuite extends PolarsTestBase {
       .ffiName shouldBe """{"Struct":[{"name":"a","dtype":"Int32"}]}"""
   }
 
-  test("datatype equality and time units (test_dtype_time_units)") {
+  test("datatype equality and time units") {
     DataTypes.datetime("ms", "UTC") should not be DataTypes.datetime("ns", "UTC")
     DataTypes.duration("ns") should not be DataTypes.duration("us")
 

--- a/core/src/test/scala/com/github/chitralverma/polars/HarnessSmokeSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/HarnessSmokeSuite.scala
@@ -4,7 +4,7 @@ import com.github.chitralverma.polars.functions._
 import com.github.chitralverma.polars.testing.PolarsTestBase
 
 /** Harness self-test (Scala): native lib loads under `Test`, a frame round-trips an expression.
-  * Not a port of an upstream pytest; the Java mirror is `HarnessSmokeTest`.
+  * The Java mirror is `HarnessSmokeTest`.
   */
 class HarnessSmokeSuite extends PolarsTestBase {
 

--- a/core/src/test/scala/com/github/chitralverma/polars/NameSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/NameSuite.scala
@@ -3,10 +3,7 @@ package com.github.chitralverma.polars
 import com.github.chitralverma.polars.functions._
 import com.github.chitralverma.polars.testing.PolarsTestBase
 
-/** Replicates behaviours tested in upstream py-polars
-  * `tests/unit/operations/namespaces/test_name.py` and asserts column aliasing (`alias`/`as`)
-  * behaviour.
-  */
+/** Tests column aliasing (`alias`/`as`) and the `name` namespace. */
 class NameSuite extends PolarsTestBase {
 
   test("expression alias and JVM-friendly as") {

--- a/core/src/test/scala/com/github/chitralverma/polars/NativeLoaderSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/NativeLoaderSuite.scala
@@ -6,8 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 /** Unit tests for `NativeLoader` — arch normalization, classpath resource paths, and the
-  * content-addressed extraction cache. Not a port of an upstream pytest; the Java mirror is
-  * `NativeLoaderTest`.
+  * content-addressed extraction cache. The Java mirror is `NativeLoaderTest`.
   */
 class NativeLoaderSuite extends AnyFunSuite with Matchers {
 

--- a/core/src/test/scala/com/github/chitralverma/polars/UnarySuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/UnarySuite.scala
@@ -4,8 +4,8 @@ import com.github.chitralverma.polars.api.expressions.Expression
 import com.github.chitralverma.polars.functions._
 import com.github.chitralverma.polars.testing.PolarsTestBase
 
-/** Replicates and asserts behaviours tested in upstream py-polars for core unary transforms and
-  * predicates, such as null/nan filters, positional slices, and unique/distinct masks.
+/** Tests core unary transforms and predicates, such as null/nan filters, positional slices, and
+  * unique/distinct masks.
   */
 class UnarySuite extends PolarsTestBase {
 

--- a/core/src/test/scala/com/github/chitralverma/polars/WhenThenSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/WhenThenSuite.scala
@@ -1,0 +1,144 @@
+package com.github.chitralverma.polars
+
+import com.github.chitralverma.polars.api.{DataFrame, Series}
+import com.github.chitralverma.polars.functions._
+import com.github.chitralverma.polars.testing.PolarsTestBase
+
+/** Tests the `when / otherwise` conditional builder. */
+class WhenThenSuite extends PolarsTestBase {
+
+  test("when/otherwise: basic branch and implicit null default") {
+    val df = intFrame("a", 1, 2, 3, 4, 5)
+
+    // With otherwise -> unmatched rows take the default.
+    val withOtherwise = df.select(
+      when(col("a") < 3, "x").otherwise("y").alias("a")
+    )
+    assertColumnValues(withOtherwise, "a", "x", "x", "y", "y", "y")
+
+    // Without otherwise -> unmatched rows are null (implicit otherwise(null)).
+    val implicitNull = df.select(when(col("a") < 3, "x").alias("b"))
+    assertColumnValues(implicitNull, "b", "x", "x", null, null, null)
+  }
+
+  test("when/otherwise: chained conditions") {
+    val df = intFrame("a", 1, 2, 3, 4, 5)
+
+    val withOtherwise = df.select(
+      when(col("a") < 3, "x")
+        .when(col("a") > 4, "z")
+        .otherwise("y")
+        .alias("a")
+    )
+    assertColumnValues(withOtherwise, "a", "x", "x", "y", "y", "z")
+
+    // Chained builder used without otherwise -> unmatched rows are null.
+    val implicitNull = df.select(
+      when(col("a") < 3, "x")
+        .when(col("a") > 4, "z")
+        .alias("b")
+    )
+    assertColumnValues(implicitNull, "b", "x", "x", null, null, "z")
+  }
+
+  test("when: bare when usable as an expression (implicit none)") {
+    val df = DataFrame.fromSeries(
+      Series.ofString("team", Array("A", "A", "A", "B", "B", "C")),
+      Series.ofInt("points", Array(11, 8, 10, 6, 6, 5))
+    )
+
+    val result = df.select(
+      when(col("points") > 7, "Foo").alias("flag")
+    )
+    assertColumnValues(result, "flag", "Foo", "Foo", "Foo", null, null, null)
+  }
+
+  test("when/otherwise: value taken from another column") {
+    val df = DataFrame.fromSeries(
+      Series.ofInt("x", Array(0, 1, 2, 3, 4)),
+      Series.ofInt("y", Array(5, 6, 7, 8, 9))
+    )
+
+    // A column expression is used directly as the branch value.
+    val result = df.select(
+      when(col("x") < 2, col("x")).otherwise(col("y")).alias("out")
+    )
+    assertColumnValues(result, "out", 0, 1, 7, 8, 9)
+  }
+
+  test("when/otherwise: string supertype coercion") {
+    // A numeric then-branch and a string otherwise-branch are coerced to a common string supertype.
+    val df = DataFrame.fromSeries(
+      Series.ofString("names", Array("foo", "spam", "spam")),
+      Series.ofInt("nrs", Array(1, 2, 3))
+    )
+
+    val result = df.select(
+      when(col("names") === "spam", col("nrs") * 2)
+        .otherwise(lit("other"))
+        .alias("new_col")
+    )
+    assertColumnValues(result, "new_col", "other", "4", "6")
+  }
+
+  test("when/otherwise: numeric supertype cascade") {
+    // Mixed Int/Double branch values are coerced to a common floating supertype.
+    val df = intFrame("foo", 1, 3, 4)
+
+    val result = df.select(
+      when(col("foo") === 1, 1)
+        .when(col("foo") === 2, 4)
+        .when(col("foo") === 3, 1.5)
+        .when(col("foo") === 4, 16)
+        .otherwise(0)
+        .alias("val")
+    )
+    assertColumnValues(result, "val", 1.0, 1.5, 16.0)
+  }
+
+  test("when/otherwise: long chain folds correctly") {
+    // A long chain frees several intermediate handles during the fold; the result must stay valid.
+    val df = intFrame("n", 1, 2, 3, 4, 5, 6, 7)
+
+    val result = df.select(
+      when(col("n") === 1, "one")
+        .when(col("n") === 2, "two")
+        .when(col("n") === 3, "three")
+        .when(col("n") === 4, "four")
+        .when(col("n") === 5, "five")
+        .when(col("n") === 6, "six")
+        .otherwise("many")
+        .alias("word")
+    )
+    assertColumnValues(result, "word", "one", "two", "three", "four", "five", "six", "many")
+  }
+
+  test("when/otherwise: nested via any_horizontal equals chained") {
+    val df = DataFrame.fromSeries(
+      Series.ofString("c1", Array("a", "b")),
+      Series.ofString("c2", Array("c", "d"))
+    )
+
+    // Nested otherwise(when(...)) form.
+    val nested = df.select(
+      when(anyHorizontal(col("c1") === "a", col("c2") === "a"), "a")
+        .otherwise(
+          when(anyHorizontal(col("c1") === "d", col("c2") === "d"), "d")
+            .otherwise(lit(null))
+        )
+        .alias("result")
+    )
+
+    // Flat chained form.
+    val chained = df.select(
+      when(anyHorizontal(col("c1") === "a", col("c2") === "a"), "a")
+        .when(anyHorizontal(col("c1") === "d", col("c2") === "d"), "d")
+        .otherwise(lit(null))
+        .alias("result")
+    )
+
+    assertColumnValues(nested, "result", "a", "d")
+    assertColumnValues(chained, "result", "a", "d")
+  }
+
+}

--- a/core/src/test/scala/com/github/chitralverma/polars/testing/PolarsTestBase.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/testing/PolarsTestBase.scala
@@ -7,9 +7,8 @@ import org.scalatest.matchers.should.Matchers
 import com.github.chitralverma.polars.api.{DataFrame, Series}
 
 /** Shared base for Scala test suites — a reusable test base, not a per-suite fixture. Suites
-  * extend it for frame-construction and assertion helpers, and should name the upstream pytest
-  * they replicate (e.g. `py-polars/tests/unit/operations/test_filter.py`) at the top of the file.
-  * The Java mirror is `AbstractPolarsJavaTest`.
+  * extend it for frame-construction and assertion helpers. The Java mirror is
+  * `AbstractPolarsJavaTest`.
   */
 abstract class PolarsTestBase extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 

--- a/native/src/internal_jni/expr/functions.rs
+++ b/native/src/internal_jni/expr/functions.rs
@@ -4,6 +4,7 @@ use jni::{Env, NativeMethod, native_method};
 use polars_plan::dsl::functions::{
     all_horizontal, any_horizontal, max_horizontal, mean_horizontal, min_horizontal, sum_horizontal,
 };
+use polars_plan::dsl::ternary_expr;
 use polars_plan::prelude::Expr;
 
 use crate::internal_jni::conversion::JavaArrayToVec;
@@ -138,6 +139,25 @@ fn mean_horizontal_expr<'local>(
     Ok(ExprHandle::alloc(expr))
 }
 
+const TERNARY_EXPR_METHOD: NativeMethod = fn_method!(
+    extern fn ternary_expr_expr(predicate: ExprHandle, truthy: ExprHandle, falsy: ExprHandle) -> ExprHandle,
+    name = "ternaryExpr",
+);
+
+fn ternary_expr_expr<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    predicate: ExprHandle,
+    truthy: ExprHandle,
+    falsy: ExprHandle,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(ternary_expr(
+        predicate.get(),
+        truthy.get(),
+        falsy.get(),
+    )))
+}
+
 pub const METHODS: &[NativeMethod] = &[
     ANY_HORIZONTAL_METHOD,
     ALL_HORIZONTAL_METHOD,
@@ -145,4 +165,5 @@ pub const METHODS: &[NativeMethod] = &[
     MIN_HORIZONTAL_METHOD,
     SUM_HORIZONTAL_METHOD,
     MEAN_HORIZONTAL_METHOD,
+    TERNARY_EXPR_METHOD,
 ];


### PR DESCRIPTION
This pull request adds the `when / otherwise` conditional builder. It makes it easy to pick a value based on a condition, like a `CASE` expression.

### What is new?

- **Entry point**: Added `functions.when(condition, value)`. It takes a condition and the value to use where that condition is true.
- **Builder**: Added the `When` class. You can add more branches with `when(condition, value)` and set a default with `otherwise(value)`. This is Spark's two-argument shape, so it reads the same in Scala and Java.
- **Implicit default**: A bare `when(...)` works as an expression on its own. Rows that do not match become null.
- **Values**: The value is used as-is if it is an expression. Any other value is treated as a literal. Use `col("x")` to pick a column.
- **Safe chains**: Bad chains do not compile. `otherwise` returns a `Column`, so you cannot call `otherwise` twice or add a `when` after it.
- **Native**: Added one small `ternaryExpr` binding. The builder does the nesting on the JVM side.
- **Tests**: Added full tests for both Scala and Java. All 84 tests pass.

### Added Functions & Namespaces

| Method / Namespace | Category | Return Type | Description |
|---|---|---|---|
| `when` | Free (functions) | `When` | Start a conditional with a condition and value |
| `When.when` | Conditional Builder | `When` | Add another condition and value |
| `When.otherwise` | Conditional Builder | `Column` | Set the default value and finish |

**Total Functions / Namespaces Added**: 3

This PR has no extra dependencies and is completely green.
