### PR TITLE
feat: add cast/math/round/trig expression transforms

### DIFF
--- a/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/api/expressions/Expression.scala
@@ -484,6 +484,331 @@ class Expression(protected[polars] val _ptr: Long) extends AutoCloseable {
   /** Compute the cumulative sum of the values. */
   def cumSum(): Column = cumSum(reverse = false)
 
+  /** Negate the values (unary minus). */
+  def neg(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.neg(ptr))
+  }
+
+  /** Negate the values (unary minus). */
+  def unary_- : Column = neg()
+
+  /** Raise the values to the given power.
+    *
+    * @param exponent
+    *   exponent to raise each value to
+    */
+  def pow(exponent: Double): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.pow(ptr, exponent))
+  }
+
+  /** Floor-divide the values by another expression.
+    *
+    * @param other
+    *   divisor expression
+    */
+  def floorDiv(other: Expression): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.floorDiv(ptr, other.ptr))
+  }
+
+  /** Round the values down to the nearest integer (floor). */
+  def floor(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.floor(ptr))
+  }
+
+  /** Round the values up to the nearest integer (ceiling). */
+  def ceil(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.ceil(ptr))
+  }
+
+  /** Round the values to the given number of decimal places.
+    *
+    * Rounding uses the round-half-to-even (banker's rounding) rule.
+    *
+    * @param decimals
+    *   number of decimal places to round to (must be >= 0)
+    */
+  def round(decimals: Int): Column = {
+    checkClosed()
+    require(decimals >= 0, s"round: 'decimals' must be >= 0, but got $decimals")
+    Column.withPtr(column_expr.round(ptr, decimals))
+  }
+
+  /** Round the values to the nearest whole number. */
+  def round(): Column = round(0)
+
+  /** Round the values to the given number of significant figures.
+    *
+    * @param digits
+    *   number of significant figures to keep (must be >= 1)
+    */
+  def roundSigFigs(digits: Int): Column = {
+    checkClosed()
+    require(digits >= 1, s"roundSigFigs: 'digits' must be >= 1, but got $digits")
+    Column.withPtr(column_expr.roundSigFigs(ptr, digits))
+  }
+
+  /** Truncate the values to the given number of decimal places, rounding toward zero.
+    *
+    * @param decimals
+    *   number of decimal places to keep (must be >= 0)
+    */
+  def truncate(decimals: Int): Column = {
+    checkClosed()
+    require(decimals >= 0, s"truncate: 'decimals' must be >= 0, but got $decimals")
+    Column.withPtr(column_expr.truncate(ptr, decimals))
+  }
+
+  /** Truncate the values toward zero, dropping any fractional part. */
+  def truncate(): Column = truncate(0)
+
+  /** Compute the absolute value of each value. */
+  def abs(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.abs(ptr))
+  }
+
+  /** Clip (limit) the values to the inclusive range defined by the given bounds.
+    *
+    * Values below `lower` become `lower`; values above `upper` become `upper`. Null values are
+    * preserved.
+    *
+    * @param lower
+    *   lower bound expression
+    * @param upper
+    *   upper bound expression
+    */
+  def clip(lower: Expression, upper: Expression): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.clip(ptr, lower.ptr, upper.ptr))
+  }
+
+  /** Clip (limit) the values so none fall below the given lower bound.
+    *
+    * Values below `lower` become `lower`; higher values are unchanged. Null values are preserved.
+    *
+    * @param lower
+    *   lower bound expression
+    */
+  def clipMin(lower: Expression): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.clipMin(ptr, lower.ptr))
+  }
+
+  /** Clip (limit) the values so none exceed the given upper bound.
+    *
+    * Values above `upper` become `upper`; lower values are unchanged. Null values are preserved.
+    *
+    * @param upper
+    *   upper bound expression
+    */
+  def clipMax(upper: Expression): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.clipMax(ptr, upper.ptr))
+  }
+
+  /** Return the sign of each value: -1 for negatives, 1 for positives, 0 for zero.
+    *
+    * Null values are preserved and NaN maps to NaN.
+    */
+  def sign(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.sign(ptr))
+  }
+
+  /** Compute the square root of each value. */
+  def sqrt(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.sqrt(ptr))
+  }
+
+  /** Compute the cube root of each value. */
+  def cbrt(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.cbrt(ptr))
+  }
+
+  /** Compute the exponential (e raised to the value) of each value. */
+  def exp(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.exp(ptr))
+  }
+
+  /** Compute the logarithm of each value to the given base.
+    *
+    * @param base
+    *   logarithm base
+    */
+  def log(base: Double): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.log(ptr, base))
+  }
+
+  /** Compute the natural logarithm (base e) of each value. */
+  def log(): Column = log(math.E)
+
+  /** Compute the base-10 logarithm of each value. */
+  def log10(): Column = log(10.0)
+
+  /** Compute the natural logarithm of one plus each value (`log(1 + x)`). */
+  def log1p(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.log1p(ptr))
+  }
+
+  /** Compute the first discrete difference between consecutive values.
+    *
+    * @param n
+    *   number of positions to look back when computing the difference
+    * @param nullBehavior
+    *   how to handle nulls: "ignore" (default) keeps them, "drop" removes them before
+    *   differencing
+    */
+  def diff(n: Long, nullBehavior: String): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.diff(ptr, n, nullBehavior))
+  }
+
+  /** Compute the first discrete difference between consecutive values, ignoring nulls.
+    *
+    * @param n
+    *   number of positions to look back when computing the difference
+    */
+  def diff(n: Long): Column = diff(n, "ignore")
+
+  /** Compute the difference between each value and the immediately preceding one. */
+  def diff(): Column = diff(1, "ignore")
+
+  /** Compute the fractional change between each value and the one `n` positions before it.
+    *
+    * @param n
+    *   number of positions to look back
+    */
+  def pctChange(n: Long): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.pctChange(ptr, n))
+  }
+
+  /** Compute the fractional change between consecutive values. */
+  def pctChange(): Column = pctChange(1)
+
+  /** Compute the sine of each value (in radians). */
+  def sin(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.sin(ptr))
+  }
+
+  /** Compute the cosine of each value (in radians). */
+  def cos(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.cos(ptr))
+  }
+
+  /** Compute the tangent of each value (in radians). */
+  def tan(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.tan(ptr))
+  }
+
+  /** Compute the cotangent of each value (in radians). */
+  def cot(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.cot(ptr))
+  }
+
+  /** Compute the inverse sine (arcsine) of each value, returning radians. */
+  def arcsin(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arcsin(ptr))
+  }
+
+  /** Compute the inverse cosine (arccosine) of each value, returning radians. */
+  def arccos(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arccos(ptr))
+  }
+
+  /** Compute the inverse tangent (arctangent) of each value, returning radians. */
+  def arctan(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arctan(ptr))
+  }
+
+  /** Compute the hyperbolic sine of each value. */
+  def sinh(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.sinh(ptr))
+  }
+
+  /** Compute the hyperbolic cosine of each value. */
+  def cosh(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.cosh(ptr))
+  }
+
+  /** Compute the hyperbolic tangent of each value. */
+  def tanh(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.tanh(ptr))
+  }
+
+  /** Compute the inverse hyperbolic sine of each value. */
+  def arcsinh(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arcsinh(ptr))
+  }
+
+  /** Compute the inverse hyperbolic cosine of each value. */
+  def arccosh(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arccosh(ptr))
+  }
+
+  /** Compute the inverse hyperbolic tangent of each value. */
+  def arctanh(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.arctanh(ptr))
+  }
+
+  /** Convert each value from radians to degrees. */
+  def degrees(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.degrees(ptr))
+  }
+
+  /** Convert each value from degrees to radians. */
+  def radians(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.radians(ptr))
+  }
+
+  /** Cast the values to their underlying physical representation.
+    *
+    * This exposes the physical storage type of logical dtypes (for example, the integer codes
+    * backing a categorical, or the primitive backing a temporal type).
+    */
+  def toPhysical(): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.toPhysical(ptr))
+  }
+
+  /** Reinterpret the bits of an integer column as another integer type of the same width.
+    *
+    * @param signed
+    *   whether to reinterpret as a signed integer; `false` reinterprets as unsigned
+    */
+  def reinterpret(signed: Boolean): Column = {
+    checkClosed()
+    Column.withPtr(column_expr.reinterpret(ptr, signed))
+  }
+
+  /** Reinterpret the bits of an integer column as a signed integer of the same width. */
+  def reinterpret(): Column = reinterpret(signed = true)
+
   override def close(): Unit = synchronized {
     if (!isClosed && _ptr != 0) {
       column_expr.free(_ptr)

--- a/core/src/main/scala/com/github/chitralverma/polars/functions.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/functions.scala
@@ -146,9 +146,55 @@ object functions {
   def cumSum(colName: String, reverse: Boolean): Column = col(colName).cumSum(reverse)
   def cumSum(colName: String): Column = col(colName).cumSum()
 
-  // --- Horizontal Aggregations ---
+  // --- Two-argument trigonometry ---
 
   import com.github.chitralverma.polars.internal.jni.expressions.functions_expr
+
+  /** Compute the element-wise arctangent of `y / x`, choosing the correct quadrant from the signs
+    * of both arguments. The result is expressed in radians.
+    *
+    * @param y
+    *   expression supplying the numerator (the "y" coordinate)
+    * @param x
+    *   expression supplying the denominator (the "x" coordinate)
+    * @return
+    *   a [[com.github.chitralverma.polars.api.expressions.Column]] of angles in radians
+    */
+  def arctan2(y: Expression, x: Expression): Column =
+    Column.withPtr(functions_expr.arctan2(y.ptr, x.ptr))
+
+  /** Compute the element-wise arctangent of `y / x` from two column names.
+    *
+    * @param yColName
+    *   name of the column supplying the numerator
+    * @param xColName
+    *   name of the column supplying the denominator
+    */
+  def arctan2(yColName: String, xColName: String): Column =
+    arctan2(col(yColName), col(xColName))
+
+  /** Compute the element-wise arctangent of `y / x` in degrees.
+    *
+    * @param y
+    *   expression supplying the numerator (the "y" coordinate)
+    * @param x
+    *   expression supplying the denominator (the "x" coordinate)
+    * @return
+    *   a [[com.github.chitralverma.polars.api.expressions.Column]] of angles in degrees
+    */
+  def arctan2d(y: Expression, x: Expression): Column = arctan2(y, x).degrees()
+
+  /** Compute the element-wise arctangent of `y / x` in degrees from two column names.
+    *
+    * @param yColName
+    *   name of the column supplying the numerator
+    * @param xColName
+    *   name of the column supplying the denominator
+    */
+  def arctan2d(yColName: String, xColName: String): Column =
+    arctan2d(col(yColName), col(xColName))
+
+  // --- Horizontal Aggregations ---
 
   @annotation.varargs
   def anyHorizontal(cols: Expression*): Column =

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/column_expr.scala
@@ -104,6 +104,80 @@ private[polars] object column_expr extends Natively {
 
   @native def cumSum(ptr: Long, reverse: Boolean): Long
 
+  @native def neg(ptr: Long): Long
+
+  @native def pow(ptr: Long, exponent: Double): Long
+
+  @native def floorDiv(ptr: Long, other: Long): Long
+
+  @native def floor(ptr: Long): Long
+
+  @native def ceil(ptr: Long): Long
+
+  @native def round(ptr: Long, decimals: Int): Long
+
+  @native def roundSigFigs(ptr: Long, digits: Int): Long
+
+  @native def truncate(ptr: Long, decimals: Int): Long
+
+  @native def abs(ptr: Long): Long
+
+  @native def clip(ptr: Long, lower: Long, upper: Long): Long
+
+  @native def clipMin(ptr: Long, lower: Long): Long
+
+  @native def clipMax(ptr: Long, upper: Long): Long
+
+  @native def sign(ptr: Long): Long
+
+  @native def sqrt(ptr: Long): Long
+
+  @native def cbrt(ptr: Long): Long
+
+  @native def exp(ptr: Long): Long
+
+  @native def log(ptr: Long, base: Double): Long
+
+  @native def log1p(ptr: Long): Long
+
+  @native def diff(ptr: Long, n: Long, nullBehavior: String): Long
+
+  @native def pctChange(ptr: Long, n: Long): Long
+
+  @native def sin(ptr: Long): Long
+
+  @native def cos(ptr: Long): Long
+
+  @native def tan(ptr: Long): Long
+
+  @native def cot(ptr: Long): Long
+
+  @native def arcsin(ptr: Long): Long
+
+  @native def arccos(ptr: Long): Long
+
+  @native def arctan(ptr: Long): Long
+
+  @native def sinh(ptr: Long): Long
+
+  @native def cosh(ptr: Long): Long
+
+  @native def tanh(ptr: Long): Long
+
+  @native def arcsinh(ptr: Long): Long
+
+  @native def arccosh(ptr: Long): Long
+
+  @native def arctanh(ptr: Long): Long
+
+  @native def degrees(ptr: Long): Long
+
+  @native def radians(ptr: Long): Long
+
+  @native def toPhysical(ptr: Long): Long
+
+  @native def reinterpret(ptr: Long, signed: Boolean): Long
+
   @native def free(ptr: Long): Unit
 
 }

--- a/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/functions_expr.scala
+++ b/core/src/main/scala/com/github/chitralverma/polars/internal/jni/expressions/functions_expr.scala
@@ -18,4 +18,6 @@ private[polars] object functions_expr extends Natively {
 
   @native def ternaryExpr(predicate: Long, truthy: Long, falsy: Long): Long
 
+  @native def arctan2(y: Long, x: Long): Long
+
 }

--- a/core/src/test/java/com/github/chitralverma/polars/MathTest.java
+++ b/core/src/test/java/com/github/chitralverma/polars/MathTest.java
@@ -1,0 +1,369 @@
+package com.github.chitralverma.polars;
+
+import static com.github.chitralverma.polars.functions.*;
+
+import com.github.chitralverma.polars.api.DataFrame;
+import com.github.chitralverma.polars.api.types.DataTypes;
+import com.github.chitralverma.polars.api.types.Int32Type$;
+import com.github.chitralverma.polars.api.types.Int64Type$;
+import com.github.chitralverma.polars.testing.AbstractPolarsJavaTest;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Java mirror of {@code MathSuite}. Tests arithmetic, rounding, logarithmic, and trigonometric
+ * expression transforms, including null propagation and the error cases the operations reject.
+ */
+public class MathTest extends AbstractPolarsJavaTest {
+
+  private static final double TOL = 1e-6;
+
+  private List<Object> valuesOf(DataFrame df, String name) {
+    return columnOf(df, name);
+  }
+
+  private void assertApprox(DataFrame df, String name, Object... expected) {
+    List<Object> actual = columnOf(df, name);
+    Assert.assertEquals("column '" + name + "' size mismatch", expected.length, actual.size());
+    for (int i = 0; i < expected.length; i++) {
+      Object e = expected[i];
+      Object a = actual.get(i);
+      if (e == null) {
+        Assert.assertNull("index " + i, a);
+      } else if (e instanceof Double) {
+        double ed = (Double) e;
+        double ad = ((Number) a).doubleValue();
+        if (Double.isNaN(ed)) {
+          Assert.assertTrue("index " + i + " expected NaN", Double.isNaN(ad));
+        } else if (Double.isInfinite(ed)) {
+          Assert.assertEquals("index " + i, ed, ad, 0.0);
+        } else {
+          Assert.assertEquals("index " + i, ed, ad, TOL);
+        }
+      } else {
+        Assert.assertEquals("index " + i, e, a);
+      }
+    }
+  }
+
+  @Test
+  public void negationPreservesNullsAndMatchesOperator() {
+    DataFrame df = intFrame("a", -1, 0, 1, 5).withColumn("a", col("a").shift(1)); // [null,-1,0,1]
+    assertApprox(df.select(col("a").neg().alias("r")), "r", null, 1, 0, -1);
+  }
+
+  @Test
+  public void negationRejectsUnsignedAndNonNumeric() {
+    DataFrame dfU = intFrame("a", 1, 2, 3);
+    try {
+      dfU.select(col("a").cast(DataTypes.UInt8).neg()).count();
+      Assert.fail("Expected RuntimeException for unsigned negation");
+    } catch (RuntimeException e) {
+      // Expected.
+    }
+
+    DataFrame dfS = stringFrame("a", "p", "q", "r");
+    try {
+      dfS.select(col("a").neg()).count();
+      Assert.fail("Expected RuntimeException for non-numeric negation");
+    } catch (RuntimeException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void powerRaisesToScalarExponent() {
+    DataFrame df = doubleFrame("x", 2.0, 3.0, 4.0);
+    assertApprox(df.select(col("x").pow(2.0).alias("r")), "r", 4.0, 9.0, 16.0);
+    assertApprox(df.select(col("x").pow(0.0).alias("r")), "r", 1.0, 1.0, 1.0);
+  }
+
+  @Test
+  public void floorDivisionRoundsTowardNegativeInfinity() {
+    DataFrame df = intFrame("a", 1, 2, 3).withColumn("d", lit(2));
+    assertApprox(df.select(col("a").floorDiv(col("d")).alias("r")), "r", 0, 1, 1);
+  }
+
+  @Test
+  public void absoluteValuePreservesNullsAndRejectsNonNumeric() {
+    DataFrame df = intFrame("a", -1, 0, 1, 5).withColumn("a", col("a").shift(1)); // [null,-1,0,1]
+    assertApprox(df.select(col("a").abs().alias("r")), "r", null, 1, 0, 1);
+
+    DataFrame dfF = doubleFrame("x", 1.0, -2.0, 3.0, -4.0);
+    assertApprox(dfF.select(col("x").abs().alias("r")), "r", 1.0, 2.0, 3.0, 4.0);
+
+    DataFrame dfS = stringFrame("a", "p", "q", "r");
+    try {
+      dfS.select(col("a").abs()).count();
+      Assert.fail("Expected RuntimeException for non-numeric abs");
+    } catch (RuntimeException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void absoluteValueOfSignedMinimumWraps() {
+    DataFrame df = intFrame("a", -128).withColumn("a", col("a").cast(DataTypes.Int8));
+    List<Object> out = valuesOf(df.select(col("a").abs().alias("r")), "r");
+    Assert.assertEquals(-128, ((Number) out.get(0)).intValue());
+  }
+
+  @Test
+  public void floorAndCeil() {
+    DataFrame dfFloor = doubleFrame("x", 1.4, 1.5, 2.5, -1.6);
+    assertApprox(dfFloor.select(col("x").floor().alias("r")), "r", 1.0, 1.0, 2.0, -2.0);
+
+    DataFrame dfCeil = doubleFrame("x", 1.8, 1.2, 3.0);
+    assertApprox(dfCeil.select(col("x").ceil().alias("r")), "r", 2.0, 2.0, 3.0);
+  }
+
+  @Test
+  public void roundUsesBankersRoundingAndIsIdentityOnIntegers() {
+    DataFrame df = doubleFrame("x", 1.003, 2.003);
+    assertApprox(df.select(col("x").round(2).alias("r")), "r", 1.0, 2.0);
+    assertApprox(df.select(col("x").round().alias("r")), "r", 1.0, 2.0);
+
+    DataFrame dfHalf = doubleFrame("x", 0.5, 1.5, 2.5, 3.5);
+    assertApprox(dfHalf.select(col("x").round().alias("r")), "r", 0.0, 2.0, 2.0, 4.0);
+
+    DataFrame dfInt = intFrame("a", 1, 2, 3);
+    assertApprox(dfInt.select(col("a").round().alias("r")), "r", 1, 2, 3);
+  }
+
+  @Test
+  public void roundSignificantFigures() {
+    DataFrame dfF = doubleFrame("x", 1.234, 0.1234);
+    assertApprox(dfF.select(col("x").roundSigFigs(2).alias("r")), "r", 1.2, 0.12);
+
+    DataFrame dfI = intFrame("a", 123400, 1234);
+    assertApprox(dfI.select(col("a").roundSigFigs(2).alias("r")), "r", 120000, 1200);
+
+    DataFrame dfZero = doubleFrame("x", 0.0);
+    assertApprox(dfZero.select(col("x").roundSigFigs(2).alias("r")), "r", 0.0);
+  }
+
+  @Test
+  public void truncateDropsFractionAcrossSpecialValues() {
+    DataFrame df = doubleFrame("x", 1.003, 2.003);
+    assertApprox(df.select(col("x").truncate(2).alias("r")), "r", 1.0, 2.0);
+    assertApprox(df.select(col("x").truncate().alias("r")), "r", 1.0, 2.0);
+
+    DataFrame dfNeg = doubleFrame("x", -1.78, -2.56, -3.99);
+    assertApprox(dfNeg.select(col("x").truncate(1).alias("r")), "r", -1.7, -2.5, -3.9);
+
+    DataFrame dfInt = intFrame("a", 1, 2, 3);
+    assertApprox(dfInt.select(col("a").truncate().alias("r")), "r", 1, 2, 3);
+
+    DataFrame dfSpecial = doubleFrame("x", 1.5, Double.NaN, Double.POSITIVE_INFINITY);
+    assertApprox(
+        dfSpecial.select(col("x").truncate(1).alias("r")),
+        "r",
+        1.5,
+        Double.NaN,
+        Double.POSITIVE_INFINITY);
+  }
+
+  @Test
+  public void signReturnsMinusOneZeroOnePreservingNullsAndNaN() {
+    DataFrame dfInt =
+        intFrame("a", -9, 0, 4, 7).withColumn("a", col("a").shift(1)); // [null,-9,0,4]
+    assertApprox(dfInt.select(col("a").sign().alias("r")), "r", null, -1, 0, 1);
+
+    DataFrame dfFloat = doubleFrame("x", -9.0, 0.0, 4.0, Double.NaN);
+    assertApprox(dfFloat.select(col("x").sign().alias("r")), "r", -1.0, 0.0, 1.0, Double.NaN);
+
+    DataFrame dfDate = intFrame("a", 1).withColumn("a", col("a").cast(DataTypes.Date));
+    try {
+      dfDate.select(col("a").sign()).count();
+      Assert.fail("Expected RuntimeException for sign of date");
+    } catch (RuntimeException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void clipLimitsToRangeAndEachSingleBound() {
+    DataFrame df = intFrame("a", 1, 2, 3, 4, 5).withColumn("mn", lit(0)).withColumn("mx", lit(2));
+    assertApprox(df.select(col("a").clip(col("mn"), col("mx")).alias("r")), "r", 1, 2, 2, 2, 2);
+    assertApprox(df.select(col("a").clipMin(col("mn")).alias("r")), "r", 1, 2, 3, 4, 5);
+    assertApprox(df.select(col("a").clipMax(col("mx")).alias("r")), "r", 1, 2, 2, 2, 2);
+  }
+
+  @Test
+  public void clipRejectsNonNumeric() {
+    DataFrame dfS = stringFrame("a", "a", "b", "c");
+    try {
+      dfS.select(col("a").clip(lit("b"), lit("z"))).count();
+      Assert.fail("Expected RuntimeException for non-numeric clip");
+    } catch (RuntimeException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void squareAndCubeRoots() {
+    DataFrame dfSqrt = doubleFrame("x", 1.0, 2.0, 4.0);
+    assertApprox(dfSqrt.select(col("x").sqrt().alias("r")), "r", 1.0, Math.sqrt(2.0), 2.0);
+
+    DataFrame dfCbrt = doubleFrame("x", 1.0, 2.0, 8.0);
+    assertApprox(dfCbrt.select(col("x").cbrt().alias("r")), "r", 1.0, Math.cbrt(2.0), 2.0);
+  }
+
+  @Test
+  public void exponentialPreservesNullsAndRunsOnEmpty() {
+    DataFrame df =
+        doubleFrame("x", 0.1, 0.01, 99.0).withColumn("x", col("x").shift(1)); // [null,0.1,0.01]
+    assertApprox(
+        df.select(col("x").exp().alias("r")), "r", null, 1.1051709180756477, 1.010050167084168);
+
+    DataFrame dfEmpty = doubleFrame("x").select(col("x").exp().alias("r"));
+    Assert.assertTrue(valuesOf(dfEmpty, "r").isEmpty());
+  }
+
+  @Test
+  public void logarithms() {
+    DataFrame df = doubleFrame("x", 1.0, 3.0, 9.0, 27.0, 81.0);
+    assertApprox(df.select(col("x").log(3.0).alias("r")), "r", 0.0, 1.0, 2.0, 3.0, 4.0);
+
+    DataFrame dfE = doubleFrame("x", 1.0, Math.E);
+    assertApprox(dfE.select(col("x").log().alias("r")), "r", 0.0, 1.0);
+
+    DataFrame dfTen = doubleFrame("x", 1.0, 10.0, 1000.0);
+    assertApprox(dfTen.select(col("x").log10().alias("r")), "r", 0.0, 1.0, 3.0);
+
+    DataFrame dfLog1p = doubleFrame("x", 0.0, Math.E - 1.0);
+    assertApprox(dfLog1p.select(col("x").log1p().alias("r")), "r", 0.0, 1.0);
+  }
+
+  @Test
+  public void differenceWithLagAndNulls() {
+    DataFrame df = intFrame("a", 10, 20, 30, 40);
+    assertApprox(df.select(col("a").diff().alias("r")), "r", null, 10, 10, 10);
+    assertApprox(df.select(col("a").diff(2).alias("r")), "r", null, null, 20, 20);
+  }
+
+  @Test
+  public void percentageChangeWithLagAndNulls() {
+    DataFrame dfPos = doubleFrame("x", 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0);
+    assertApprox(
+        dfPos.select(col("x").pctChange(2).alias("r")), "r", null, null, 3.0, 3.0, 3.0, 3.0, 3.0);
+
+    DataFrame dfNull =
+        doubleFrame("x", 10.0, 11.0, 12.0, 999.0, 12.0, 24.0)
+            .withColumn("x", when(col("x").equalTo(999.0), lit(null)).otherwise(col("x")));
+    assertApprox(
+        dfNull.select(col("x").pctChange().alias("r")), "r", null, 0.1, 0.090909, null, null, 1.0);
+  }
+
+  @Test
+  public void trigonometricInRadiansPreservesNullsAndNaN() {
+    DataFrame df =
+        doubleFrame("x", 0.0, Math.PI, Double.NaN, -1.0)
+            .withColumn("x", col("x").shift(1)); // [null,0.0,Pi,NaN]
+
+    assertApprox(
+        df.select(col("x").sin().alias("r")), "r", null, 0.0, Math.sin(Math.PI), Double.NaN);
+    assertApprox(df.select(col("x").cos().alias("r")), "r", null, 1.0, -1.0, Double.NaN);
+    assertApprox(
+        df.select(col("x").tan().alias("r")), "r", null, 0.0, Math.tan(Math.PI), Double.NaN);
+
+    List<Object> cot = valuesOf(df.select(col("x").cot().alias("r")), "r");
+    Assert.assertNull(cot.get(0));
+    Assert.assertEquals(Double.POSITIVE_INFINITY, ((Number) cot.get(1)).doubleValue(), 0.0);
+    Assert.assertTrue(Double.isNaN(((Number) cot.get(3)).doubleValue()));
+  }
+
+  @Test
+  public void inverseAndHyperbolicTrigonometric() {
+    DataFrame dfInv = doubleFrame("x", 0.0, 1.0);
+    assertApprox(dfInv.select(col("x").arcsin().alias("r")), "r", 0.0, Math.PI / 2);
+    assertApprox(dfInv.select(col("x").arccos().alias("r")), "r", Math.PI / 2, 0.0);
+    assertApprox(dfInv.select(col("x").arctan().alias("r")), "r", 0.0, Math.PI / 4);
+
+    DataFrame df = doubleFrame("x", 0.0, 1.0);
+    assertApprox(df.select(col("x").sinh().alias("r")), "r", 0.0, Math.sinh(1.0));
+    assertApprox(df.select(col("x").cosh().alias("r")), "r", 1.0, Math.cosh(1.0));
+    assertApprox(df.select(col("x").tanh().alias("r")), "r", 0.0, Math.tanh(1.0));
+    assertApprox(df.select(col("x").arcsinh().alias("r")), "r", 0.0, 0.881373587019543);
+    assertApprox(df.select(col("x").arctanh().alias("r")), "r", 0.0, Double.POSITIVE_INFINITY);
+
+    DataFrame dfCosh = doubleFrame("x", 1.0, 2.0);
+    assertApprox(dfCosh.select(col("x").arccosh().alias("r")), "r", 0.0, 1.3169578969248166);
+  }
+
+  @Test
+  public void trigonometricRejectsNonNumeric() {
+    DataFrame dfS = stringFrame("a", "1", "2", "3");
+    try {
+      dfS.select(col("a").sin()).count();
+      Assert.fail("Expected RuntimeException for non-numeric sin");
+    } catch (RuntimeException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void degreeAndRadianConversion() {
+    DataFrame dfDeg = doubleFrame("x", 0.0, Math.PI);
+    assertApprox(dfDeg.select(col("x").degrees().alias("r")), "r", 0.0, 180.0);
+
+    DataFrame dfRad = doubleFrame("x", 0.0, 180.0);
+    assertApprox(dfRad.select(col("x").radians().alias("r")), "r", 0.0, Math.PI);
+  }
+
+  @Test
+  public void twoArgumentArctangentChoosesCorrectQuadrant() {
+    DataFrame df = doubleFrame("y", 1.0, 1.0, -1.0).withColumn("x", lit(1.0));
+
+    assertApprox(
+        df.select(arctan2(col("y"), col("x")).alias("r")),
+        "r",
+        Math.PI / 4,
+        Math.PI / 4,
+        -Math.PI / 4);
+    assertApprox(df.select(arctan2d(col("y"), col("x")).alias("r")), "r", 45.0, 45.0, -45.0);
+    assertApprox(
+        df.select(arctan2("y", "x").alias("r")), "r", Math.PI / 4, Math.PI / 4, -Math.PI / 4);
+  }
+
+  @Test
+  public void physicalRepresentationOfIntegerIsIdentity() {
+    DataFrame df = intFrame("a", 1, 2, 3);
+    assertApprox(df.select(col("a").toPhysical().alias("r")), "r", 1, 2, 3);
+
+    DataFrame dfDate = intFrame("a", 0, 1, 2).withColumn("a", col("a").cast(DataTypes.Date));
+    DataFrame physical = dfDate.select(col("a").toPhysical().alias("r"));
+    Assert.assertEquals(Int32Type$.MODULE$, physical.schema().getField("r").get().dataType());
+  }
+
+  @Test
+  public void reinterpretUnsignedAsSignedKeepsBitPattern() {
+    DataFrame df = longFrame("a", 1L, 1L, 2L);
+    DataFrame out = df.select(col("a").cast(DataTypes.UInt64).reinterpret(true).alias("r"));
+    assertApprox(out, "r", 1L, 1L, 2L);
+    Assert.assertEquals(Int64Type$.MODULE$, out.schema().getField("r").get().dataType());
+  }
+
+  @Test
+  public void inputValidationForRoundingParameters() {
+    try {
+      col("a").round(-1);
+      Assert.fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected.
+    }
+    try {
+      col("a").roundSigFigs(0);
+      Assert.fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected.
+    }
+    try {
+      col("a").truncate(-1);
+      Assert.fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected.
+    }
+  }
+}

--- a/core/src/test/scala/com/github/chitralverma/polars/MathSuite.scala
+++ b/core/src/test/scala/com/github/chitralverma/polars/MathSuite.scala
@@ -1,0 +1,332 @@
+package com.github.chitralverma.polars
+
+import com.github.chitralverma.polars.api.types._
+import com.github.chitralverma.polars.functions._
+import com.github.chitralverma.polars.testing.PolarsTestBase
+
+/** Tests arithmetic, rounding, logarithmic, and trigonometric expression transforms, covering
+  * null propagation, special float values (NaN and infinity), and the input types the operations
+  * reject.
+  */
+class MathSuite extends PolarsTestBase {
+
+  private val tol = 1e-6
+
+  private def valuesOf(df: api.DataFrame, name: String): Seq[AnyRef] = columnOf(df, name)
+
+  private def assertApprox(df: api.DataFrame, name: String, expected: Any*): Unit = {
+    val actual = valuesOf(df, name)
+    actual.length shouldBe expected.length
+    actual.zip(expected).foreach {
+      case (a, null) => a shouldBe null
+      case (a, e: Double) =>
+        val d = a.asInstanceOf[Double]
+        if (e.isNaN) d.isNaN shouldBe true
+        else if (e.isInfinite) d shouldBe e
+        else d shouldBe (e +- tol)
+      case (a, e) => a shouldBe e
+    }
+  }
+
+  test("negation preserves nulls and matches the operator form") {
+    val df = intFrame("a", -1, 0, 1, 5).withColumn("a", col("a").shift(1)) // [null, -1, 0, 1]
+
+    assertApprox(df.select(col("a").neg().alias("r")), "r", null, 1, 0, -1)
+    assertApprox(df.select((-col("a")).alias("r")), "r", null, 1, 0, -1)
+  }
+
+  test("negation rejects unsigned and non-numeric inputs") {
+    val dfU = intFrame("a", 1, 2, 3)
+    assertThrows[RuntimeException](dfU.select(col("a").cast(UInt8Type).neg()).count())
+
+    val dfS = stringFrame("a", "p", "q", "r")
+    assertThrows[RuntimeException](dfS.select(col("a").neg()).count())
+  }
+
+  test("power raises values to a scalar exponent") {
+    val df = doubleFrame("x", 2.0, 3.0, 4.0)
+    assertApprox(df.select(col("x").pow(2.0).alias("r")), "r", 4.0, 9.0, 16.0)
+    assertApprox(df.select(col("x").pow(0.0).alias("r")), "r", 1.0, 1.0, 1.0)
+  }
+
+  test("floor division rounds the quotient toward negative infinity") {
+    val df = intFrame("a", 1, 2, 3).withColumn("d", lit(2))
+    assertApprox(df.select(col("a").floorDiv(col("d")).alias("r")), "r", 0, 1, 1)
+  }
+
+  test("absolute value preserves nulls and rejects non-numeric input") {
+    val df = intFrame("a", -1, 0, 1, 5).withColumn("a", col("a").shift(1)) // [null, -1, 0, 1]
+    assertApprox(df.select(col("a").abs().alias("r")), "r", null, 1, 0, 1)
+
+    // Operator and method forms agree.
+    val dfF = doubleFrame("x", 1.0, -2.0, 3.0, -4.0)
+    assertApprox(dfF.select(col("x").abs().alias("r")), "r", 1.0, 2.0, 3.0, 4.0)
+
+    val dfS = stringFrame("a", "p", "q", "r")
+    assertThrows[RuntimeException](dfS.select(col("a").abs()).count())
+  }
+
+  test("absolute value of a signed integer minimum wraps") {
+    // The two's-complement minimum has no positive counterpart and wraps back to itself.
+    val df = intFrame("a", -128).withColumn("a", col("a").cast(Int8Type))
+    assertApprox(df.select(col("a").abs().alias("r")), "r", (-128).toByte)
+  }
+
+  test("floor and ceil round toward and away from zero") {
+    val dfFloor = doubleFrame("x", 1.4, 1.5, 2.5, -1.6)
+    assertApprox(dfFloor.select(col("x").floor().alias("r")), "r", 1.0, 1.0, 2.0, -2.0)
+
+    val dfCeil = doubleFrame("x", 1.8, 1.2, 3.0)
+    assertApprox(dfCeil.select(col("x").ceil().alias("r")), "r", 2.0, 2.0, 3.0)
+  }
+
+  test("round uses banker's rounding and is identity on integers") {
+    val df = doubleFrame("x", 1.003, 2.003)
+    assertApprox(df.select(col("x").round(2).alias("r")), "r", 1.0, 2.0)
+    assertApprox(df.select(col("x").round().alias("r")), "r", 1.0, 2.0)
+
+    // Round-half-to-even: 1.5 and 2.5 both round to 2.
+    val dfHalf = doubleFrame("x", 0.5, 1.5, 2.5, 3.5)
+    assertApprox(dfHalf.select(col("x").round().alias("r")), "r", 0.0, 2.0, 2.0, 4.0)
+
+    // Rounding an integer column leaves it unchanged.
+    val dfInt = intFrame("a", 1, 2, 3)
+    assertApprox(dfInt.select(col("a").round().alias("r")), "r", 1, 2, 3)
+  }
+
+  test("round to significant figures works for floats and integers") {
+    val dfF = doubleFrame("x", 1.234, 0.1234)
+    assertApprox(dfF.select(col("x").roundSigFigs(2).alias("r")), "r", 1.2, 0.12)
+
+    val dfI = intFrame("a", 123400, 1234)
+    assertApprox(dfI.select(col("a").roundSigFigs(2).alias("r")), "r", 120000, 1200)
+
+    val dfZero = doubleFrame("x", 0.0)
+    assertApprox(dfZero.select(col("x").roundSigFigs(2).alias("r")), "r", 0.0)
+  }
+
+  test("truncate drops the fractional part toward zero across special values") {
+    val df = doubleFrame("x", 1.003, 2.003)
+    assertApprox(df.select(col("x").truncate(2).alias("r")), "r", 1.0, 2.0)
+    assertApprox(df.select(col("x").truncate().alias("r")), "r", 1.0, 2.0)
+
+    // Truncation of negatives rounds toward zero.
+    val dfNeg = doubleFrame("x", -1.78, -2.56, -3.99)
+    assertApprox(dfNeg.select(col("x").truncate(1).alias("r")), "r", -1.7, -2.5, -3.9)
+
+    // Integers are unchanged.
+    val dfInt = intFrame("a", 1, 2, 3)
+    assertApprox(dfInt.select(col("a").truncate().alias("r")), "r", 1, 2, 3)
+
+    // NaN, infinity, and null flow through unchanged.
+    val dfSpecial = doubleFrame("x", 1.5, Double.NaN, Double.PositiveInfinity)
+    assertApprox(
+      dfSpecial.select(col("x").truncate(1).alias("r")),
+      "r",
+      1.5,
+      Double.NaN,
+      Double.PositiveInfinity
+    )
+  }
+
+  test("sign returns -1, 0, or 1 and preserves nulls and NaN") {
+    val dfInt = intFrame("a", -9, 0, 4, 7).withColumn("a", col("a").shift(1)) // [null, -9, 0, 4]
+    assertApprox(dfInt.select(col("a").sign().alias("r")), "r", null, -1, 0, 1)
+
+    val dfFloat = doubleFrame("x", -9.0, 0.0, 4.0, Double.NaN)
+    assertApprox(dfFloat.select(col("x").sign().alias("r")), "r", -1.0, 0.0, 1.0, Double.NaN)
+
+    // Sign of a date column is not defined.
+    val dfDate = intFrame("a", 1).withColumn("a", col("a").cast(DateType))
+    assertThrows[RuntimeException](dfDate.select(col("a").sign()).count())
+  }
+
+  test("clip limits values to a range and each single bound") {
+    val df = intFrame("a", 1, 2, 3, 4, 5).withColumn("mn", lit(0)).withColumn("mx", lit(2))
+
+    assertApprox(df.select(col("a").clip(col("mn"), col("mx")).alias("r")), "r", 1, 2, 2, 2, 2)
+    assertApprox(df.select(col("a").clipMin(col("mn")).alias("r")), "r", 1, 2, 3, 4, 5)
+    assertApprox(df.select(col("a").clipMax(col("mx")).alias("r")), "r", 1, 2, 2, 2, 2)
+  }
+
+  test("clip rejects non-numeric input") {
+    val dfS = stringFrame("a", "a", "b", "c")
+    assertThrows[RuntimeException](dfS.select(col("a").clip(lit("b"), lit("z"))).count())
+  }
+
+  test("square and cube roots") {
+    val dfSqrt = doubleFrame("x", 1.0, 2.0, 4.0)
+    assertApprox(dfSqrt.select(col("x").sqrt().alias("r")), "r", 1.0, math.sqrt(2.0), 2.0)
+
+    val dfCbrt = doubleFrame("x", 1.0, 2.0, 8.0)
+    assertApprox(dfCbrt.select(col("x").cbrt().alias("r")), "r", 1.0, math.cbrt(2.0), 2.0)
+  }
+
+  test("exponential preserves nulls and runs on an empty column") {
+    val df =
+      doubleFrame("x", 0.1, 0.01, 99.0).withColumn("x", col("x").shift(1)) // [null, 0.1, 0.01]
+    assertApprox(
+      df.select(col("x").exp().alias("r")),
+      "r",
+      null,
+      1.1051709180756477,
+      1.010050167084168
+    )
+
+    val dfEmpty = doubleFrame("x").select(col("x").exp().alias("r"))
+    valuesOf(dfEmpty, "r") shouldBe empty
+  }
+
+  test("logarithms with an arbitrary base and the base-e, base-10, and log1p forms") {
+    val df = doubleFrame("x", 1.0, 3.0, 9.0, 27.0, 81.0)
+    assertApprox(df.select(col("x").log(3.0).alias("r")), "r", 0.0, 1.0, 2.0, 3.0, 4.0)
+
+    val dfE = doubleFrame("x", 1.0, math.E)
+    assertApprox(dfE.select(col("x").log().alias("r")), "r", 0.0, 1.0)
+
+    val dfTen = doubleFrame("x", 1.0, 10.0, 1000.0)
+    assertApprox(dfTen.select(col("x").log10().alias("r")), "r", 0.0, 1.0, 3.0)
+
+    val dfLog1p = doubleFrame("x", 0.0, math.E - 1.0)
+    assertApprox(dfLog1p.select(col("x").log1p().alias("r")), "r", 0.0, 1.0)
+  }
+
+  test("difference between consecutive elements with lag and null handling") {
+    val df = intFrame("a", 10, 20, 30, 40)
+    // The first row has no predecessor and becomes null.
+    assertApprox(df.select(col("a").diff().alias("r")), "r", null, 10, 10, 10)
+    assertApprox(df.select(col("a").diff(2).alias("r")), "r", null, null, 20, 20)
+  }
+
+  test("percentage change over a lag, handling nulls") {
+    val dfPos = doubleFrame("x", 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0)
+    assertApprox(
+      dfPos.select(col("x").pctChange(2).alias("r")),
+      "r",
+      null,
+      null,
+      3.0,
+      3.0,
+      3.0,
+      3.0,
+      3.0
+    )
+
+    // A null in the middle produces null both at that row and the following comparison.
+    val dfNull = doubleFrame("x", 10.0, 11.0, 12.0, 999.0, 12.0, 24.0)
+      .withColumn("x", when(col("x") === 999.0, lit(null)).otherwise(col("x")))
+    assertApprox(
+      dfNull.select(col("x").pctChange().alias("r")),
+      "r",
+      null,
+      0.1,
+      0.090909,
+      null,
+      null,
+      1.0
+    )
+  }
+
+  test("trigonometric transforms in radians preserve nulls and NaN") {
+    val df = doubleFrame("x", 0.0, math.Pi, Double.NaN, -1.0)
+      .withColumn("x", col("x").shift(1)) // [null, 0.0, Pi, NaN]
+
+    assertApprox(
+      df.select(col("x").sin().alias("r")),
+      "r",
+      null,
+      0.0,
+      math.sin(math.Pi),
+      Double.NaN
+    )
+    assertApprox(df.select(col("x").cos().alias("r")), "r", null, 1.0, -1.0, Double.NaN)
+    assertApprox(
+      df.select(col("x").tan().alias("r")),
+      "r",
+      null,
+      0.0,
+      math.tan(math.Pi),
+      Double.NaN
+    )
+
+    // Cotangent is undefined at 0 (positive infinity) and preserves nulls and NaN.
+    val cot = valuesOf(df.select(col("x").cot().alias("r")), "r")
+    cot.head shouldBe null
+    cot(1).asInstanceOf[Double] shouldBe Double.PositiveInfinity
+    cot(3).asInstanceOf[Double].isNaN shouldBe true
+  }
+
+  test("inverse and hyperbolic trigonometric transforms") {
+    val dfInv = doubleFrame("x", 0.0, 1.0)
+    assertApprox(dfInv.select(col("x").arcsin().alias("r")), "r", 0.0, math.Pi / 2)
+    assertApprox(dfInv.select(col("x").arccos().alias("r")), "r", math.Pi / 2, 0.0)
+    assertApprox(dfInv.select(col("x").arctan().alias("r")), "r", 0.0, math.Pi / 4)
+
+    val df = doubleFrame("x", 0.0, 1.0)
+    assertApprox(df.select(col("x").sinh().alias("r")), "r", 0.0, math.sinh(1.0))
+    assertApprox(df.select(col("x").cosh().alias("r")), "r", 1.0, math.cosh(1.0))
+    assertApprox(df.select(col("x").tanh().alias("r")), "r", 0.0, math.tanh(1.0))
+    assertApprox(df.select(col("x").arcsinh().alias("r")), "r", 0.0, 0.881373587019543)
+    assertApprox(df.select(col("x").arctanh().alias("r")), "r", 0.0, Double.PositiveInfinity)
+
+    val dfCosh = doubleFrame("x", 1.0, 2.0)
+    assertApprox(dfCosh.select(col("x").arccosh().alias("r")), "r", 0.0, 1.3169578969248166)
+  }
+
+  test("trigonometric transforms reject non-numeric input") {
+    val dfS = stringFrame("a", "1", "2", "3")
+    assertThrows[RuntimeException](dfS.select(col("a").sin()).count())
+  }
+
+  test("degree and radian conversion") {
+    val dfDeg = doubleFrame("x", 0.0, math.Pi)
+    assertApprox(dfDeg.select(col("x").degrees().alias("r")), "r", 0.0, 180.0)
+
+    val dfRad = doubleFrame("x", 0.0, 180.0)
+    assertApprox(dfRad.select(col("x").radians().alias("r")), "r", 0.0, math.Pi)
+  }
+
+  test("two-argument arctangent chooses the correct quadrant") {
+    val df = doubleFrame("y", 1.0, 1.0, -1.0).withColumn("x", lit(1.0))
+
+    assertApprox(
+      df.select(arctan2(col("y"), col("x")).alias("r")),
+      "r",
+      math.Pi / 4,
+      math.Pi / 4,
+      -math.Pi / 4
+    )
+    assertApprox(df.select(arctan2d(col("y"), col("x")).alias("r")), "r", 45.0, 45.0, -45.0)
+    // The column-name overloads delegate to the expression forms.
+    assertApprox(
+      df.select(arctan2("y", "x").alias("r")),
+      "r",
+      math.Pi / 4,
+      math.Pi / 4,
+      -math.Pi / 4
+    )
+  }
+
+  test("physical representation of an integer column is an identity") {
+    val df = intFrame("a", 1, 2, 3)
+    assertApprox(df.select(col("a").toPhysical().alias("r")), "r", 1, 2, 3)
+
+    // A date column exposes its Int32 day-offset physical form.
+    val dfDate = intFrame("a", 0, 1, 2).withColumn("a", col("a").cast(DateType))
+    val physical = dfDate.select(col("a").toPhysical().alias("r"))
+    physical.schema.getField("r").get.dataType shouldBe Int32Type
+  }
+
+  test("reinterpreting an unsigned integer as signed keeps the bit pattern") {
+    val df = longFrame("a", 1L, 1L, 2L)
+    val out = df.select(col("a").cast(UInt64Type).reinterpret(signed = true).alias("r"))
+    assertApprox(out, "r", 1L, 1L, 2L)
+    out.schema.getField("r").get.dataType shouldBe Int64Type
+  }
+
+  test("input validation for rounding parameters") {
+    an[IllegalArgumentException] shouldBe thrownBy(col("a").round(-1))
+    an[IllegalArgumentException] shouldBe thrownBy(col("a").roundSigFigs(0))
+    an[IllegalArgumentException] shouldBe thrownBy(col("a").truncate(-1))
+  }
+}

--- a/native/src/internal_jni/expr/column.rs
+++ b/native/src/internal_jni/expr/column.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Rem, Sub};
+use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
 use anyhow::Context;
 use jni::objects::{JObject, JObjectArray, JString};
@@ -7,6 +7,7 @@ use jni::{Env, NativeMethod, jni_sig, jni_str, native_method};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use polars::prelude::*;
+use polars_core::series::ops::NullBehavior;
 
 use crate::internal_jni::handle::{ExprHandle, Handle};
 use crate::internal_jni::macros::decl_free;
@@ -106,6 +107,31 @@ decl_unary_expr! {
     (LAST_METHOD, last, "last", last),
     (ARG_MIN_METHOD, arg_min, "argMin", arg_min),
     (ARG_MAX_METHOD, arg_max, "argMax", arg_max),
+    (NEG_METHOD, neg, "neg", neg),
+    (FLOOR_METHOD, floor, "floor", floor),
+    (CEIL_METHOD, ceil, "ceil", ceil),
+    (ABS_METHOD, abs, "abs", abs),
+    (SIGN_METHOD, sign, "sign", sign),
+    (SQRT_METHOD, sqrt, "sqrt", sqrt),
+    (CBRT_METHOD, cbrt, "cbrt", cbrt),
+    (EXP_METHOD, exp, "exp", exp),
+    (LOG1P_METHOD, log1p, "log1p", log1p),
+    (TO_PHYSICAL_METHOD, to_physical, "toPhysical", to_physical),
+    (SIN_METHOD, sin, "sin", sin),
+    (COS_METHOD, cos, "cos", cos),
+    (TAN_METHOD, tan, "tan", tan),
+    (COT_METHOD, cot, "cot", cot),
+    (ARCSIN_METHOD, arcsin, "arcsin", arcsin),
+    (ARCCOS_METHOD, arccos, "arccos", arccos),
+    (ARCTAN_METHOD, arctan, "arctan", arctan),
+    (SINH_METHOD, sinh, "sinh", sinh),
+    (COSH_METHOD, cosh, "cosh", cosh),
+    (TANH_METHOD, tanh, "tanh", tanh),
+    (ARCSINH_METHOD, arcsinh, "arcsinh", arcsinh),
+    (ARCCOSH_METHOD, arccosh, "arccosh", arccosh),
+    (ARCTANH_METHOD, arctanh, "arctanh", arctanh),
+    (DEGREES_METHOD, degrees, "degrees", degrees),
+    (RADIANS_METHOD, radians, "radians", radians),
 }
 
 const COLUMN_METHOD: NativeMethod =
@@ -656,6 +682,156 @@ fn cum_sum<'local>(
     Ok(ExprHandle::alloc(expr.get().cum_sum(reverse)))
 }
 
+const POW_METHOD: NativeMethod =
+    col_method!(extern fn pow(expr: ExprHandle, exponent: jdouble) -> ExprHandle, name = "pow",);
+
+fn pow<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    exponent: jdouble,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().pow(lit(exponent))))
+}
+
+const FLOOR_DIV_METHOD: NativeMethod = col_method!(extern fn floor_div(expr: ExprHandle, other: ExprHandle) -> ExprHandle, name = "floorDiv",);
+
+fn floor_div<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    other: ExprHandle,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().floor_div(other.get())))
+}
+
+const ROUND_METHOD: NativeMethod =
+    col_method!(extern fn round(expr: ExprHandle, decimals: jint) -> ExprHandle, name = "round",);
+
+fn round<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    decimals: jint,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(
+        expr.get().round(decimals as u32, RoundMode::HalfToEven),
+    ))
+}
+
+const ROUND_SIG_FIGS_METHOD: NativeMethod = col_method!(extern fn round_sig_figs(expr: ExprHandle, digits: jint) -> ExprHandle, name = "roundSigFigs",);
+
+fn round_sig_figs<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    digits: jint,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().round_sig_figs(digits)))
+}
+
+const TRUNCATE_METHOD: NativeMethod = col_method!(extern fn truncate(expr: ExprHandle, decimals: jint) -> ExprHandle, name = "truncate",);
+
+fn truncate<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    decimals: jint,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().truncate(decimals as u32)))
+}
+
+const CLIP_METHOD: NativeMethod = col_method!(extern fn clip(expr: ExprHandle, lower: ExprHandle, upper: ExprHandle) -> ExprHandle, name = "clip",);
+
+fn clip<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    lower: ExprHandle,
+    upper: ExprHandle,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().clip(lower.get(), upper.get())))
+}
+
+const CLIP_MIN_METHOD: NativeMethod = col_method!(extern fn clip_min(expr: ExprHandle, lower: ExprHandle) -> ExprHandle, name = "clipMin",);
+
+fn clip_min<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    lower: ExprHandle,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().clip_min(lower.get())))
+}
+
+const CLIP_MAX_METHOD: NativeMethod = col_method!(extern fn clip_max(expr: ExprHandle, upper: ExprHandle) -> ExprHandle, name = "clipMax",);
+
+fn clip_max<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    upper: ExprHandle,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().clip_max(upper.get())))
+}
+
+const LOG_METHOD: NativeMethod =
+    col_method!(extern fn log(expr: ExprHandle, base: jdouble) -> ExprHandle, name = "log",);
+
+fn log<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    base: jdouble,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().log(lit(base))))
+}
+
+const DIFF_METHOD: NativeMethod = col_method!(extern fn diff(expr: ExprHandle, n: jlong, null_behavior: java.lang.String) -> ExprHandle, name = "diff",);
+
+fn diff<'local>(
+    env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    n: jlong,
+    null_behavior: JString<'local>,
+) -> anyhow::Result<ExprHandle> {
+    let behavior = j_string_to_string(
+        env,
+        &null_behavior,
+        Some("Failed to parse null behavior as string"),
+    )?;
+    let nb = match behavior.to_lowercase().as_str() {
+        "drop" => NullBehavior::Drop,
+        _ => NullBehavior::Ignore,
+    };
+    Ok(ExprHandle::alloc(expr.get().diff(lit(n), nb)))
+}
+
+const PCT_CHANGE_METHOD: NativeMethod = col_method!(extern fn pct_change(expr: ExprHandle, n: jlong) -> ExprHandle, name = "pctChange",);
+
+fn pct_change<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    n: jlong,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(expr.get().pct_change(lit(n))))
+}
+
+const REINTERPRET_METHOD: NativeMethod = col_method!(extern fn reinterpret(expr: ExprHandle, signed: bool) -> ExprHandle, name = "reinterpret",);
+
+fn reinterpret<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    expr: ExprHandle,
+    signed: bool,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(
+        expr.get().reinterpret(Some(signed), None),
+    ))
+}
+
 decl_free!(
     FREE_METHOD,
     "com.github.chitralverma.polars.internal.jni.expressions.column_expr$",
@@ -688,6 +864,31 @@ pub const METHODS: &[NativeMethod] = &[
     LAST_METHOD,
     ARG_MIN_METHOD,
     ARG_MAX_METHOD,
+    NEG_METHOD,
+    FLOOR_METHOD,
+    CEIL_METHOD,
+    ABS_METHOD,
+    SIGN_METHOD,
+    SQRT_METHOD,
+    CBRT_METHOD,
+    EXP_METHOD,
+    LOG1P_METHOD,
+    TO_PHYSICAL_METHOD,
+    SIN_METHOD,
+    COS_METHOD,
+    TAN_METHOD,
+    COT_METHOD,
+    ARCSIN_METHOD,
+    ARCCOS_METHOD,
+    ARCTAN_METHOD,
+    SINH_METHOD,
+    COSH_METHOD,
+    TANH_METHOD,
+    ARCSINH_METHOD,
+    ARCCOSH_METHOD,
+    ARCTANH_METHOD,
+    DEGREES_METHOD,
+    RADIANS_METHOD,
     COLUMN_METHOD,
     SORT_COLUMN_BY_NAME_METHOD,
     APPLY_UNARY_METHOD,
@@ -713,5 +914,17 @@ pub const METHODS: &[NativeMethod] = &[
     ANY_METHOD,
     ALL_METHOD,
     CUM_SUM_METHOD,
+    POW_METHOD,
+    FLOOR_DIV_METHOD,
+    ROUND_METHOD,
+    ROUND_SIG_FIGS_METHOD,
+    TRUNCATE_METHOD,
+    CLIP_METHOD,
+    CLIP_MIN_METHOD,
+    CLIP_MAX_METHOD,
+    LOG_METHOD,
+    DIFF_METHOD,
+    PCT_CHANGE_METHOD,
+    REINTERPRET_METHOD,
     FREE_METHOD,
 ];

--- a/native/src/internal_jni/expr/functions.rs
+++ b/native/src/internal_jni/expr/functions.rs
@@ -158,6 +158,20 @@ fn ternary_expr_expr<'local>(
     )))
 }
 
+const ARCTAN2_METHOD: NativeMethod = fn_method!(
+    extern fn arctan2_expr(y: ExprHandle, x: ExprHandle) -> ExprHandle,
+    name = "arctan2",
+);
+
+fn arctan2_expr<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    y: ExprHandle,
+    x: ExprHandle,
+) -> anyhow::Result<ExprHandle> {
+    Ok(ExprHandle::alloc(y.get().arctan2(x.get())))
+}
+
 pub const METHODS: &[NativeMethod] = &[
     ANY_HORIZONTAL_METHOD,
     ALL_HORIZONTAL_METHOD,
@@ -166,4 +180,5 @@ pub const METHODS: &[NativeMethod] = &[
     SUM_HORIZONTAL_METHOD,
     MEAN_HORIZONTAL_METHOD,
     TERNARY_EXPR_METHOD,
+    ARCTAN2_METHOD,
 ];


### PR DESCRIPTION
This PR adds the numeric expression transforms to the expression API: arithmetic helpers, rounding and math, logarithms, and the full set of trigonometric functions. It also adds the two-argument arctangent as a free function.

### What is new?

- **Arithmetic**: negation (`neg` / unary `-`), power, and floor division.
- **Rounding and math**: `floor`, `ceil`, `round` (half-to-even), `roundSigFigs`, `truncate`, `abs`, `clip` with single-bound `clipMin` / `clipMax`, and `sign`.
- **Roots, exponent, logs**: `sqrt`, `cbrt`, `exp`, `log` (any base), `log10`, `log1p`.
- **Change**: `diff` (with lag) and `pctChange`.
- **Trigonometry**: `sin`, `cos`, `tan`, `cot`, the inverse forms, the hyperbolic forms, and `degrees` / `radians`. Plus `arctan2` / `arctan2d` as free functions.
- **Dtype shape**: `toPhysical` and `reinterpret`.
- **Tests**: 52 new tests (26 Scala, 26 Java) covering null handling, NaN and infinity, error cases, and dtype behaviour. Full suite 136/136 green.

### Added Functions & Namespaces

| Method / Namespace | Category | Return Type | Description |
| --- | --- | --- | --- |
| `Expression.neg` / `unary_-` | Arithmetic | `Column` | Negate the values |
| `Expression.pow` | Arithmetic | `Column` | Raise to a scalar power |
| `Expression.floorDiv` | Arithmetic | `Column` | Floor divide by another expression |
| `Expression.floor` | Rounding | `Column` | Round down |
| `Expression.ceil` | Rounding | `Column` | Round up |
| `Expression.round` | Rounding | `Column` | Round to decimals (half-to-even) |
| `Expression.roundSigFigs` | Rounding | `Column` | Round to significant figures |
| `Expression.truncate` | Rounding | `Column` | Drop the fractional part toward zero |
| `Expression.abs` | Math | `Column` | Absolute value |
| `Expression.clip` | Math | `Column` | Clip to a lower and upper bound |
| `Expression.clipMin` | Math | `Column` | Clip to a lower bound |
| `Expression.clipMax` | Math | `Column` | Clip to an upper bound |
| `Expression.sign` | Math | `Column` | Sign of the values |
| `Expression.sqrt` | Math | `Column` | Square root |
| `Expression.cbrt` | Math | `Column` | Cube root |
| `Expression.exp` | Math | `Column` | Exponential |
| `Expression.log` | Math | `Column` | Logarithm to a base |
| `Expression.log10` | Math | `Column` | Base-10 logarithm |
| `Expression.log1p` | Math | `Column` | Natural log of 1 + x |
| `Expression.diff` | Change | `Column` | Difference between elements |
| `Expression.pctChange` | Change | `Column` | Fractional change over a lag |
| `Expression.sin` / `cos` / `tan` / `cot` | Trigonometry | `Column` | Trigonometric functions |
| `Expression.arcsin` / `arccos` / `arctan` | Trigonometry | `Column` | Inverse trigonometric functions |
| `Expression.sinh` / `cosh` / `tanh` | Trigonometry | `Column` | Hyperbolic functions |
| `Expression.arcsinh` / `arccosh` / `arctanh` | Trigonometry | `Column` | Inverse hyperbolic functions |
| `Expression.degrees` / `radians` | Trigonometry | `Column` | Angle unit conversion |
| `Expression.toPhysical` | Dtype | `Column` | Cast to the physical representation |
| `Expression.reinterpret` | Dtype | `Column` | Reinterpret integer bits as signed/unsigned |
| `functions.arctan2` | Trigonometry | `Column` | Two-argument arctangent (radians) |
| `functions.arctan2d` | Trigonometry | `Column` | Two-argument arctangent (degrees) |

**Total New Methods Added**: 37 (35 on `Expression` + 2 free functions).

No new dependencies. All checks green.
